### PR TITLE
fix(patch): use modified options in fetch override instead of original arguments

### DIFF
--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1276,7 +1276,7 @@ services:
   openhands:
     image: ",
                   {
-                    "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:8ca040813fac75a0ca6724701daadc584c2a1ebb1d9f7e39e53682bb38e6f0bf",
+                    "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:2069b46b24700872f5d76c682d2468038381c801b1b81c809b5bb34e89e2c57c",
                   },
                   "
     container_name: openhands-app
@@ -1436,7 +1436,7 @@ aws ecr get-login-password --region $REGION | docker login --username AWS --pass
 pull_with_retry() { local img=$1; for i in 1 2 3; do docker pull "$img" && return 0; sleep 15; done; return 1; }
 pull_with_retry "",
                   {
-                    "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:8ca040813fac75a0ca6724701daadc584c2a1ebb1d9f7e39e53682bb38e6f0bf",
+                    "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:2069b46b24700872f5d76c682d2468038381c801b1b81c809b5bb34e89e2c57c",
                   },
                   ""
 pull_with_retry "",


### PR DESCRIPTION
## Summary

- Fix MCP server deduplication by intercepting XMLHttpRequest instead of fetch
- Add protection for global MCP servers (prevent edit/delete of config.toml servers)

## Problem

1. **MCP Duplication Bug**: When users saved any setting via the OpenHands UI, global MCP servers were being duplicated in the user's settings.

2. **Accidental Modification**: Users could accidentally edit or delete system-managed MCP servers configured in config.toml.

## Solution

### Fix 1: MCP Deduplication (XMLHttpRequest interception)
- OpenHands frontend uses Axios which defaults to XMLHttpRequest, not `window.fetch`
- Replaced fetch interception with XMLHttpRequest.prototype.open/send interception
- Use Object.defineProperty for safe property storage
- Add defensive null checks and type guards

### Fix 2: Global MCP Server Protection
- Disable Edit/Delete buttons for system-managed MCP servers
- Servers defined in config.toml (chrome-devtools, knowledge-mcp) are read-only
- Buttons are grayed out with tooltip explaining they're system-managed
- Uses MutationObserver to handle SPA navigation

## Test plan

- [x] Build passes (`npm run build`)
- [x] Unit tests pass (`npm run test`)
- [x] CI checks pass
- [x] Reviewer bot findings addressed (all threads resolved)
- [x] Deployed to staging (previous commit)
- [x] E2E tests pass - verified:
  - Console shows "Settings patch: Filtered out 2 global MCP server(s)"
  - S3 settings.json has empty mcp_config (no duplicates)
  - MCP settings page shows exactly 2 servers (no duplicates)
- [ ] Deploy MCP protection feature (pending - registry unavailable)

## Checklist

- [x] Root cause identified and fixed (XMLHttpRequest, not fetch)
- [x] Snapshot updated for docker image hash change
- [x] E2E verification complete on staging
- [x] All Q reviewer findings addressed
- [x] Global MCP server protection added