### PR TITLE
fix(auth): use SameSite=None for cookies to enable runtime subdomain access

### DIFF
--- a/lib/lambda-edge/auth-handler.js
+++ b/lib/lambda-edge/auth-handler.js
@@ -387,14 +387,14 @@ exports.handler = async (event) => {
               // Build new cookies
               const idTokenExpiry = new Date(Date.now() + ID_TOKEN_EXPIRY_MS).toUTCString();
               const setCookies = [
-                { key: 'Set-Cookie', value: `id_token=${tokens.id_token}; Domain=${CONFIG.cookieDomain}; Path=/; Expires=${idTokenExpiry}; HttpOnly; Secure; SameSite=Lax` },
+                { key: 'Set-Cookie', value: `id_token=${tokens.id_token}; Domain=${CONFIG.cookieDomain}; Path=/; Expires=${idTokenExpiry}; HttpOnly; Secure; SameSite=None` },
               ];
 
               if (tokens.refresh_token) {
                 const refreshTokenExpiry = new Date(Date.now() + REFRESH_TOKEN_EXPIRY_MS).toUTCString();
                 setCookies.push({
                   key: 'Set-Cookie',
-                  value: `refresh_token=${tokens.refresh_token}; Domain=${CONFIG.cookieDomain}; Path=/; Expires=${refreshTokenExpiry}; HttpOnly; Secure; SameSite=Lax`,
+                  value: `refresh_token=${tokens.refresh_token}; Domain=${CONFIG.cookieDomain}; Path=/; Expires=${refreshTokenExpiry}; HttpOnly; Secure; SameSite=None`,
                 });
               }
 
@@ -513,14 +513,14 @@ exports.handler = async (event) => {
       const refreshTokenExpiry = new Date(Date.now() + REFRESH_TOKEN_EXPIRY_MS).toUTCString();
 
       const setCookies = [
-        { key: 'Set-Cookie', value: `id_token=${tokens.id_token}; Domain=${CONFIG.cookieDomain}; Path=/; Expires=${idTokenExpiry}; HttpOnly; Secure; SameSite=Lax` },
+        { key: 'Set-Cookie', value: `id_token=${tokens.id_token}; Domain=${CONFIG.cookieDomain}; Path=/; Expires=${idTokenExpiry}; HttpOnly; Secure; SameSite=None` },
       ];
 
       // Store refresh_token if provided (enables silent token refresh)
       if (tokens.refresh_token) {
         setCookies.push({
           key: 'Set-Cookie',
-          value: `refresh_token=${tokens.refresh_token}; Domain=${CONFIG.cookieDomain}; Path=/; Expires=${refreshTokenExpiry}; HttpOnly; Secure; SameSite=Lax`,
+          value: `refresh_token=${tokens.refresh_token}; Domain=${CONFIG.cookieDomain}; Path=/; Expires=${refreshTokenExpiry}; HttpOnly; Secure; SameSite=None`,
         });
       }
 
@@ -627,7 +627,7 @@ exports.handler = async (event) => {
       // Set new cookies
       const idTokenExpiry = new Date(Date.now() + ID_TOKEN_EXPIRY_MS).toUTCString();
       const setCookies = [
-        { key: 'Set-Cookie', value: `id_token=${tokens.id_token}; Domain=${CONFIG.cookieDomain}; Path=/; Expires=${idTokenExpiry}; HttpOnly; Secure; SameSite=Lax` },
+        { key: 'Set-Cookie', value: `id_token=${tokens.id_token}; Domain=${CONFIG.cookieDomain}; Path=/; Expires=${idTokenExpiry}; HttpOnly; Secure; SameSite=None` },
       ];
 
       // Cognito may return a new refresh_token (token rotation)
@@ -635,7 +635,7 @@ exports.handler = async (event) => {
         const refreshTokenExpiry = new Date(Date.now() + REFRESH_TOKEN_EXPIRY_MS).toUTCString();
         setCookies.push({
           key: 'Set-Cookie',
-          value: `refresh_token=${tokens.refresh_token}; Domain=${CONFIG.cookieDomain}; Path=/; Expires=${refreshTokenExpiry}; HttpOnly; Secure; SameSite=Lax`,
+          value: `refresh_token=${tokens.refresh_token}; Domain=${CONFIG.cookieDomain}; Path=/; Expires=${refreshTokenExpiry}; HttpOnly; Secure; SameSite=None`,
         });
       }
 
@@ -708,7 +708,7 @@ exports.handler = async (event) => {
           // Build new cookies
           const idTokenExpiry = new Date(Date.now() + ID_TOKEN_EXPIRY_MS).toUTCString();
           const setCookies = [
-            { key: 'Set-Cookie', value: `id_token=${tokens.id_token}; Domain=${CONFIG.cookieDomain}; Path=/; Expires=${idTokenExpiry}; HttpOnly; Secure; SameSite=Lax` },
+            { key: 'Set-Cookie', value: `id_token=${tokens.id_token}; Domain=${CONFIG.cookieDomain}; Path=/; Expires=${idTokenExpiry}; HttpOnly; Secure; SameSite=None` },
           ];
 
           // Update refresh_token if rotated
@@ -716,7 +716,7 @@ exports.handler = async (event) => {
             const refreshTokenExpiry = new Date(Date.now() + REFRESH_TOKEN_EXPIRY_MS).toUTCString();
             setCookies.push({
               key: 'Set-Cookie',
-              value: `refresh_token=${tokens.refresh_token}; Domain=${CONFIG.cookieDomain}; Path=/; Expires=${refreshTokenExpiry}; HttpOnly; Secure; SameSite=Lax`,
+              value: `refresh_token=${tokens.refresh_token}; Domain=${CONFIG.cookieDomain}; Path=/; Expires=${refreshTokenExpiry}; HttpOnly; Secure; SameSite=None`,
             });
           }
 

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -2287,14 +2287,14 @@ exports.handler = async (event) => {
               // Build new cookies
               const idTokenExpiry = new Date(Date.now() + ID_TOKEN_EXPIRY_MS).toUTCString();
               const setCookies = [
-                { key: 'Set-Cookie', value: \`id_token=\${tokens.id_token}; Domain=\${CONFIG.cookieDomain}; Path=/; Expires=\${idTokenExpiry}; HttpOnly; Secure; SameSite=Lax\` },
+                { key: 'Set-Cookie', value: \`id_token=\${tokens.id_token}; Domain=\${CONFIG.cookieDomain}; Path=/; Expires=\${idTokenExpiry}; HttpOnly; Secure; SameSite=None\` },
               ];
 
               if (tokens.refresh_token) {
                 const refreshTokenExpiry = new Date(Date.now() + REFRESH_TOKEN_EXPIRY_MS).toUTCString();
                 setCookies.push({
                   key: 'Set-Cookie',
-                  value: \`refresh_token=\${tokens.refresh_token}; Domain=\${CONFIG.cookieDomain}; Path=/; Expires=\${refreshTokenExpiry}; HttpOnly; Secure; SameSite=Lax\`,
+                  value: \`refresh_token=\${tokens.refresh_token}; Domain=\${CONFIG.cookieDomain}; Path=/; Expires=\${refreshTokenExpiry}; HttpOnly; Secure; SameSite=None\`,
                 });
               }
 
@@ -2413,14 +2413,14 @@ exports.handler = async (event) => {
       const refreshTokenExpiry = new Date(Date.now() + REFRESH_TOKEN_EXPIRY_MS).toUTCString();
 
       const setCookies = [
-        { key: 'Set-Cookie', value: \`id_token=\${tokens.id_token}; Domain=\${CONFIG.cookieDomain}; Path=/; Expires=\${idTokenExpiry}; HttpOnly; Secure; SameSite=Lax\` },
+        { key: 'Set-Cookie', value: \`id_token=\${tokens.id_token}; Domain=\${CONFIG.cookieDomain}; Path=/; Expires=\${idTokenExpiry}; HttpOnly; Secure; SameSite=None\` },
       ];
 
       // Store refresh_token if provided (enables silent token refresh)
       if (tokens.refresh_token) {
         setCookies.push({
           key: 'Set-Cookie',
-          value: \`refresh_token=\${tokens.refresh_token}; Domain=\${CONFIG.cookieDomain}; Path=/; Expires=\${refreshTokenExpiry}; HttpOnly; Secure; SameSite=Lax\`,
+          value: \`refresh_token=\${tokens.refresh_token}; Domain=\${CONFIG.cookieDomain}; Path=/; Expires=\${refreshTokenExpiry}; HttpOnly; Secure; SameSite=None\`,
         });
       }
 
@@ -2527,7 +2527,7 @@ exports.handler = async (event) => {
       // Set new cookies
       const idTokenExpiry = new Date(Date.now() + ID_TOKEN_EXPIRY_MS).toUTCString();
       const setCookies = [
-        { key: 'Set-Cookie', value: \`id_token=\${tokens.id_token}; Domain=\${CONFIG.cookieDomain}; Path=/; Expires=\${idTokenExpiry}; HttpOnly; Secure; SameSite=Lax\` },
+        { key: 'Set-Cookie', value: \`id_token=\${tokens.id_token}; Domain=\${CONFIG.cookieDomain}; Path=/; Expires=\${idTokenExpiry}; HttpOnly; Secure; SameSite=None\` },
       ];
 
       // Cognito may return a new refresh_token (token rotation)
@@ -2535,7 +2535,7 @@ exports.handler = async (event) => {
         const refreshTokenExpiry = new Date(Date.now() + REFRESH_TOKEN_EXPIRY_MS).toUTCString();
         setCookies.push({
           key: 'Set-Cookie',
-          value: \`refresh_token=\${tokens.refresh_token}; Domain=\${CONFIG.cookieDomain}; Path=/; Expires=\${refreshTokenExpiry}; HttpOnly; Secure; SameSite=Lax\`,
+          value: \`refresh_token=\${tokens.refresh_token}; Domain=\${CONFIG.cookieDomain}; Path=/; Expires=\${refreshTokenExpiry}; HttpOnly; Secure; SameSite=None\`,
         });
       }
 
@@ -2608,7 +2608,7 @@ exports.handler = async (event) => {
           // Build new cookies
           const idTokenExpiry = new Date(Date.now() + ID_TOKEN_EXPIRY_MS).toUTCString();
           const setCookies = [
-            { key: 'Set-Cookie', value: \`id_token=\${tokens.id_token}; Domain=\${CONFIG.cookieDomain}; Path=/; Expires=\${idTokenExpiry}; HttpOnly; Secure; SameSite=Lax\` },
+            { key: 'Set-Cookie', value: \`id_token=\${tokens.id_token}; Domain=\${CONFIG.cookieDomain}; Path=/; Expires=\${idTokenExpiry}; HttpOnly; Secure; SameSite=None\` },
           ];
 
           // Update refresh_token if rotated
@@ -2616,7 +2616,7 @@ exports.handler = async (event) => {
             const refreshTokenExpiry = new Date(Date.now() + REFRESH_TOKEN_EXPIRY_MS).toUTCString();
             setCookies.push({
               key: 'Set-Cookie',
-              value: \`refresh_token=\${tokens.refresh_token}; Domain=\${CONFIG.cookieDomain}; Path=/; Expires=\${refreshTokenExpiry}; HttpOnly; Secure; SameSite=Lax\`,
+              value: \`refresh_token=\${tokens.refresh_token}; Domain=\${CONFIG.cookieDomain}; Path=/; Expires=\${refreshTokenExpiry}; HttpOnly; Secure; SameSite=None\`,
             });
           }
 
@@ -2706,7 +2706,7 @@ module.exports = {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "AuthFunctionCurrentVersionDB17CE860ae7fc20db587d20a1fc3e9205c50a95": {
+    "AuthFunctionCurrentVersionDB17CE8692427b5d938324a0ac7648d1cc9339b4": {
       "Metadata": {
         "aws:cdk:do-not-refactor": true,
       },
@@ -2935,7 +2935,7 @@ module.exports = {
                   "EventType": "viewer-request",
                   "IncludeBody": false,
                   "LambdaFunctionARN": {
-                    "Ref": "AuthFunctionCurrentVersionDB17CE860ae7fc20db587d20a1fc3e9205c50a95",
+                    "Ref": "AuthFunctionCurrentVersionDB17CE8692427b5d938324a0ac7648d1cc9339b4",
                   },
                 },
               ],
@@ -2970,7 +2970,7 @@ module.exports = {
                 "EventType": "viewer-request",
                 "IncludeBody": false,
                 "LambdaFunctionARN": {
-                  "Ref": "AuthFunctionCurrentVersionDB17CE860ae7fc20db587d20a1fc3e9205c50a95",
+                  "Ref": "AuthFunctionCurrentVersionDB17CE8692427b5d938324a0ac7648d1cc9339b4",
                 },
               },
               {


### PR DESCRIPTION
## Summary

- Changed all `SameSite=Lax` to `SameSite=None` in Lambda@Edge auth handler (8 occurrences)
- Enables cookies to be sent on cross-subdomain fetch requests to runtime subdomains

## Root Cause

`SameSite=Lax` cookies are NOT sent on cross-subdomain fetch requests:
- Frontend at `openhands.test.kane.mx` makes fetch to `*.runtime.openhands.test.kane.mx`
- Browser treats this as cross-site → doesn't send Lax cookies
- Lambda@Edge receives 0 id_tokens → returns 401

## Why SameSite=None is Safe Here

1. **First-party context** - Both domains belong to the same application
2. **Secure attribute** - Already set, required for SameSite=None
3. **HttpOnly attribute** - Preserved, prevents XSS-based cookie theft
4. **JWT verification** - Lambda@Edge validates tokens on each request
5. **Ownership verification** - OpenResty verifies user owns the conversation

## Test plan

- [x] Build passes (`npm run build`)
- [x] Unit tests pass (`npm run test`)
- [x] CI checks pass
- [x] Reviewer bot findings addressed (no new findings)
- [x] Deployed to staging
- [x] E2E tests pass

## Checklist

- [x] No new unit tests needed (existing tests validate cookie handling)
- [x] E2E test cases cover this scenario
- [x] Documentation not needed (internal security config)