### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-02-02
+
+### Added
+
+#### Cost Management
+- **Dynamic cost allocation tags** via CDK context (#14)
+  - `STAGE` tag auto-detected from domainName (`test.*` → staging, otherwise production)
+  - `Project` and `Purpose` tags configurable via `--context` parameters
+  - All tags integrated with AWS Cost Allocation for billing visibility
+
+### Fixed
+
+#### Authentication & Security
+- **Runtime subdomain cookie access** - Changed `SameSite=Lax` to `SameSite=None` in Lambda@Edge auth handler to enable cookies on cross-subdomain fetch requests (#16)
+- **npm package vulnerabilities** - Added override for `fast-xml-parser` to v5.3.4 to fix GHSA-37qj-frw5-hhjh RangeError DoS bug (#18)
+
+#### Sandbox & Conversation Resume
+- **Conversation resume after EC2 replacement** - Pass `OH_SECRET_KEY` to sandbox containers via Secrets Manager for encrypted secrets decryption (#17)
+- **Bedrock token expiration** - Fixed by using EC2 instance role instead of sandbox STS credentials for LLM calls (#17)
+
+#### Frontend Patches
+- **MCP server deduplication** - Intercept XMLHttpRequest instead of fetch to prevent global MCP servers from being duplicated in user settings (#15)
+- **Global MCP server protection** - Disable Edit/Delete buttons for system-managed MCP servers defined in config.toml (#15)
+
+[0.2.0]: https://github.com/zxkane/openhands-infra/releases/tag/v0.2.0
+
 ## [0.1.0] - 2026-01-29
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhands-infra",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "bin": {
     "openhands-infra": "bin/openhands-infra.js"
   },


### PR DESCRIPTION
## Summary

Release v0.2.0 with the following changes since v0.1.0:

### Added
- **Dynamic cost allocation tags** via CDK context (#14)
  - `STAGE` tag auto-detected from domainName
  - `Project` and `Purpose` tags configurable via `--context` parameters

### Fixed
- **Runtime subdomain cookie access** - `SameSite=None` for cross-subdomain fetch (#16)
- **npm package vulnerabilities** - `fast-xml-parser` override to v5.3.4 (#18)
- **Conversation resume** - Pass `OH_SECRET_KEY` via Secrets Manager (#17)
- **Bedrock token expiration** - Use EC2 instance role for LLM calls (#17)
- **MCP server deduplication** - XMLHttpRequest interception (#15)
- **Global MCP server protection** - Disable Edit/Delete for system servers (#15)

## Test plan

- [x] Build passes (`npm run build`)
- [x] Changes are documentation only (CHANGELOG.md, package.json version)

## After Merge

Create release with:
```bash
git tag -a v0.2.0 -m "Release v0.2.0" && git push origin v0.2.0
gh release create v0.2.0 --title "v0.2.0" --notes-file CHANGELOG.md
```