### PR TITLE
refactor(security): reference sandbox secret key via IaC instead of dynamic creation

### DIFF
--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -63,6 +63,8 @@ export interface SecurityStackOutput {
   userSecretsKmsKeyArn?: string;
   /** KMS key ID for user secrets encryption (optional, only when user config enabled) */
   userSecretsKmsKeyId?: string;
+  /** Secrets Manager secret name for sandbox secret key */
+  sandboxSecretKeyName: string;
 }
 
 /**

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1249,20 +1249,9 @@ retry mount -a
 mountpoint -q /data/openhands || exit 1
 mkdir -p /data/openhands/{config,workspace,.openhands} && chown -R ec2-user:ec2-user /data/openhands
 set +x
-echo "Retrieving or creating sandbox secret key..."
-OH_SECRET_KEY=$(aws secretsmanager get-secret-value --secret-id openhands/sandbox-secret-key --region "$REGION" --query SecretString --output text 2>/dev/null)
-if [ -z "$OH_SECRET_KEY" ]; then
-  echo "Secret not found, generating new key..."
-  SK=$(openssl rand -base64 32)
-  if aws secretsmanager create-secret --name openhands/sandbox-secret-key --secret-string "$SK" --region "$REGION" --description "OpenHands sandbox secret key" 2>/dev/null; then
-    echo "Secret created successfully"
-    OH_SECRET_KEY="$SK"
-  else
-    echo "Create failed (race condition?), retrieving existing secret..."
-    OH_SECRET_KEY=$(aws secretsmanager get-secret-value --secret-id openhands/sandbox-secret-key --region "$REGION" --query SecretString --output text)
-  fi
-fi
-[ -n "$OH_SECRET_KEY" ] || { echo "ERROR: Failed to get/create sandbox secret key" >&2; exit 1; }
+echo "Retrieving sandbox secret key..."
+OH_SECRET_KEY=$(aws secretsmanager get-secret-value --secret-id openhands/sandbox-secret-key --region "$REGION" --query SecretString --output text)
+[ -n "$OH_SECRET_KEY" ] || { echo "ERROR: Failed to retrieve sandbox secret key" >&2; exit 1; }
 export OH_SECRET_KEY
 echo "Sandbox secret key configured"
 set -x
@@ -4166,11 +4155,21 @@ exports[`OpenHands Infrastructure Stacks SecurityStack matches snapshot 1`] = `
             {
               "Action": [
                 "secretsmanager:GetSecretValue",
-                "secretsmanager:CreateSecret",
+                "secretsmanager:DescribeSecret",
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:secretsmanager:us-west-2:123456789012:secret:openhands/sandbox-secret-key-*",
-              "Sid": "SecretsManagerAccess",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":secretsmanager:us-west-2:123456789012:secret:openhands/sandbox-secret-key-??????",
+                  ],
+                ],
+              },
             },
             {
               "Action": "ecr:GetAuthorizationToken",


### PR DESCRIPTION
## Summary
- Use `fromSecretNameV2` to reference pre-existing secret in SecurityStack instead of creating dynamically in EC2 user data
- Remove `CreateSecret` permission from EC2 role (read-only access now)
- Simplify EC2 user data script to only read the secret
- Add `sandboxSecretKeyName` to SecurityStackOutput interface

## Why
The previous implementation created the secret dynamically in EC2 user data, which caused:
- Race conditions if EC2 launched before secret existed
- Extra permissions (`secretsmanager:CreateSecret`) on EC2 role
- Secret not managed by IaC

## Migration
For new environments, create the secret before deploying:
```bash
aws secretsmanager create-secret --name openhands/sandbox-secret-key \
  --secret-string "$(openssl rand -base64 32)" --region <region> \
  --description "OpenHands sandbox secret key for session encryption"
```

## Test plan
- [x] Build passes (`npm run build`)
- [x] All tests pass (`npm run test`)
- [x] Deployed to production (openhands.aws.kane.mx)
- [x] Target group healthy
- [x] Site accessible and redirects to Cognito login