### PR TITLE
fix(docker): update OpenResty base image to 1.27.1.2 for CVE remediation

### DIFF
--- a/docker/openresty/Dockerfile
+++ b/docker/openresty/Dockerfile
@@ -1,7 +1,7 @@
 # OpenResty runtime proxy
 # Routes /runtime/{conversation_id}/{port}/... to sandbox Fargate task IP:port
 # Discovers sandbox IPs via the Sandbox Orchestrator API (Cloud Map DNS)
-FROM openresty/openresty:1.25.3.1-alpine-fat
+FROM openresty/openresty:1.27.1.2-alpine-fat
 
 # Install lua-resty-http for Orchestrator API communication
 # alpine-fat image includes opm (OpenResty Package Manager)

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1432,7 +1432,7 @@ security_analyzer = "llm"",
               "Timeout": 10,
             },
             "Image": {
-              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:c4fa87e4543ce1900a092883d73c9706d29ea892c903b389da33c349237078f8",
+              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:da5d8270e90b49e9ea6e1f4a6cb789e1146a4c3d8006fa689c34fb2706c5b003",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -1740,7 +1740,7 @@ security_analyzer = "llm"",
               "Timeout": 5,
             },
             "Image": {
-              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:710de61fd844f4eb8aaffc590ebcd84df56eee8b61af7ba0c6bba30dea48b5de",
+              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:7845f2affa444e40d330cd6ed218fc42c19e61914cc754f25722ea3dfe808e71",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",


### PR DESCRIPTION
## Summary

Update OpenResty base image from `1.25.3.1-alpine-fat` to `1.27.1.2-alpine-fat` to address critical container CVEs reported by Mirador security scanning (Finding Type: `CONTAINER_REMEDIATION.CONTAINER_REMEDIATION_REQUIRED`).

- **Current image**: `openresty/openresty:1.25.3.1-alpine-fat`
- **Updated image**: `openresty/openresty:1.27.1.2-alpine-fat` (latest stable, updated Feb 13, 2026)

This resolves OS-level package vulnerabilities in the Alpine base image that were flagged as Critical severity and Out of SLA.

## Test plan

- [x] Build passes (`npm run build`)
- [x] Unit tests pass (`npm run test`) - 95/95 tests passing
- [x] CI checks pass
- [x] Reviewer bot findings addressed (no new findings)
- [x] Deployed to staging
- [x] **E2E tests pass**
  - [x] TC-003: Login
  - [x] TC-004: Conversation List
  - [x] TC-005: New Conversation
  - [x] TC-006: Execute Flask Todo App
  - [x] TC-007: Verify Runtime Accessible (subdomain routing)
  - [x] TC-008: Verify In-App Routing (path-based routing)
  - [x] TC-009: Verify Web App Subdomain

## Checklist

- [x] Snapshot updated for new Docker image asset hash
- [x] Documentation updated if needed (N/A - no new features)