### PR TITLE
docs: comprehensive update for ECS Fargate architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,17 @@ npx cdk diff --all --context ...
 - `subDomain` - Optional, defaults to "openhands"
 - `region` - Optional, defaults to us-east-1
 
+### Optional Context Parameters
+
+- `skipS3Endpoint` - Skip S3 Gateway endpoint if VPC already has one
+- `sandboxAwsAccess` - Enable sandbox AWS access (default: false)
+- `sandboxAwsPolicyFile` - Path to custom IAM policy for sandbox
+- `warmPoolSize` - Pre-warmed sandbox Fargate tasks (default: 2)
+- `idleTimeoutMinutes` - Sandbox idle timeout (default: 30, staging: 10)
+- `edgeStackSuffix` - Suffix for Edge stack name (multi-environment)
+- `authCallbackDomains` - OAuth callback domains (JSON array or comma-separated)
+- `authDomainPrefixSuffix` - Cognito domain prefix suffix (default: "shared")
+
 ### Prerequisites (First-Time Deployment)
 
 Create sandbox secret key before first deployment:
@@ -127,13 +138,17 @@ Must include **both** file-system and access-point ARNs in IAM policies.
 |------|---------|
 | `bin/openhands-infra.ts` | CDK entry point |
 | `lib/interfaces.ts` | Stack I/O interfaces |
-| `lib/*-stack.ts` | Individual stack definitions |
+| `lib/*-stack.ts` | Individual stack definitions (10 stacks) |
 | `lib/cluster-stack.ts` | Shared ECS cluster + Cloud Map |
+| `lib/sandbox-stack.ts` | Sandbox orchestration (DynamoDB, Lambda, Fargate tasks) |
 | `config/config.toml` | OpenHands app config (LLM, sandbox) |
 | `config/sandbox-aws-policy.json` | Customizable IAM policy for sandbox |
 | `docker/patch-fix.js` | Frontend patches (URL rewriting) |
 | `docker/openresty/` | OpenResty proxy container (Fargate service) |
 | `lambda/user-config/` | User config API Lambda |
+| `lambda/sandbox-monitor/` | Sandbox idle monitor Lambda |
+| `lambda/sandbox-task-state/` | ECS task state change handler Lambda |
+| `lambda/db-bootstrap/` | Database bootstrap custom resource Lambda |
 | `lib/lambda-edge/` | Lambda@Edge handlers |
 | `test/E2E_TEST_CASES.md` | E2E test cases |
 | `docs/ARCHITECTURE.md` | Architecture deep dive |
@@ -147,7 +162,7 @@ Per-user customization stored in S3:
 - **Encrypted Secrets**: API keys with KMS envelope encryption
 - **Integrations**: GitHub, Slack with auto-MCP support
 
-Feature flag: `USER_CONFIG_ENABLED` environment variable on EC2.
+Feature flag: `USER_CONFIG_ENABLED` environment variable on Fargate app service (auto-set when KMS key exists).
 
 ## Runtime Subdomain Routing
 

--- a/README.md
+++ b/README.md
@@ -5,35 +5,40 @@ AWS CDK TypeScript project for deploying [OpenHands](https://github.com/All-Hand
 ## Architecture Overview
 
 ```
-User → CloudFront (WAF+Lambda@Edge Auth) → HTTP Origin → ALB (origin verified) → EC2 m7g.xlarge Graviton (ASG)
-           │                                                                              ↓
-           └── Cognito (OAuth2, Managed Login v2)                             OpenHands Docker + Watchtower
-                                                                                          ↓
-                                                                        VPC Endpoints → Bedrock / CloudWatch Logs
-                                                                                          ↓
-                                                                        RDS Proxy → Aurora Serverless v2 PostgreSQL
+User → CloudFront (WAF+Lambda@Edge Auth) → ALB (origin verified) → ECS Fargate (App + OpenResty)
+           │                                                                  ↓
+           └── Cognito (OAuth2, Managed Login v2)                  Cloud Map → Sandbox Fargate Tasks
+                                                                              ↓
+                                                        VPC Endpoints → Bedrock / CloudWatch Logs
+                                                                              ↓
+                                                        RDS Proxy → Aurora Serverless v2 PostgreSQL
+
+Sandbox Orchestration:
+App → Orchestrator Lambda → DynamoDB Registry → Sandbox Fargate Tasks (per-conversation EFS isolation)
 
 Runtime Apps:
-{port}-{convId}.runtime.{subdomain}.{domain} → CloudFront → Lambda@Edge → OpenResty → Docker Container
+{port}-{convId}.runtime.{subdomain}.{domain} → CloudFront → Lambda@Edge → OpenResty → Sandbox Fargate Task
 ```
 
 Key features:
+- **ECS Fargate**: Fully serverless compute — App, OpenResty, and sandbox containers all run on Fargate
 - **CloudFront with Origin Verification**: ALB requires X-Origin-Verify header - direct access returns 403
-- **Internet-facing ALB**: Required for WebSocket support (CloudFront VPC Origin doesn't support WebSocket)
-- **Self-Healing Architecture**: Conversation history persists across EC2 instance replacements
+- **Per-Conversation Isolation**: Each sandbox gets a dedicated EFS access point, preventing cross-conversation access
+- **Self-Healing Architecture**: Conversation history persists across Fargate task replacements
 - **Runtime Subdomain Routing**: User apps accessible via `{port}-{convId}.runtime.{subdomain}.{domain}` with proper in-app routing
 
 ## Features
 
-- **Graviton (ARM64)**: Cost-optimized m7g.xlarge instances (~20% cheaper than x86)
+- **ECS Fargate (ARM64)**: Fully serverless compute for App, OpenResty, and sandbox containers
+- **Per-Conversation Sandbox Isolation**: Each conversation gets a dedicated EFS access point and Fargate task
 - **AWS Bedrock**: LLM inference via IAM Role (no API keys)
 - **Aurora Serverless v2**: PostgreSQL database with RDS Proxy for connection pooling and high availability
-- **S3 Data Persistence**: Conversation events, settings stored in S3 (survives instance replacement)
-- **EFS Workspace Persistence**: Sandbox workspaces stored in EFS under `/data/openhands` (survives instance replacement)
-- **Self-Healing**: ASG with ELB health checks + persistent database = no data loss on instance replacement
-- **Auto-updates**: Watchtower for Docker image updates
-- **Security**: Cognito auth (30-day session), WAF, VPC Endpoints, private subnets, Secrets Manager
-- **Monitoring**: CloudWatch Logs, Alarms, Dashboard
+- **S3 Data Persistence**: Conversation events, settings stored in S3 (survives task replacement)
+- **EFS Workspace Persistence**: Per-conversation EFS access points at `/sandbox-workspace/<conversation_id>/`
+- **Self-Healing**: Fargate services + persistent database + S3 + EFS = no data loss on task replacement
+- **Sandbox Orchestrator**: Lambda-based orchestrator manages sandbox lifecycle via DynamoDB registry
+- **Security**: Cognito auth (30-day session), WAF, VPC Endpoints, private subnets, Secrets Manager, KMS
+- **Monitoring**: CloudWatch Logs, Alarms, Container Insights
 - **Backup**: AWS Backup with 14-day retention, Aurora automatic backups (35 days)
 - **Runtime Subdomain**: Apps run at domain root with proper internal routing and cookie isolation
 - **Sandbox AWS Access**: Optional feature enabling sandbox containers to access AWS services with scoped IAM credentials
@@ -41,7 +46,7 @@ Key features:
 ## Prerequisites
 
 - AWS CLI configured with appropriate credentials
-- Node.js 20+ and npm
+- Node.js 22+ and npm
 - Existing VPC with private subnets and NAT Gateway
 - Existing Route 53 Hosted Zone
 
@@ -70,6 +75,9 @@ Required context parameters:
 | `edgeStackSuffix` | Suffix for Edge stack name in us-east-1 (optional; enables multiple Edge stacks) | `my-project` |
 | `sandboxAwsAccess` | Enable sandbox AWS access (optional, defaults to false) | `true` |
 | `sandboxAwsPolicyFile` | Path to custom IAM policy JSON for sandbox (optional) | `config/sandbox-aws-policy.json` |
+| `skipS3Endpoint` | Skip S3 Gateway endpoint if VPC already has one (optional) | `true` |
+| `warmPoolSize` | Number of pre-warmed sandbox Fargate tasks (optional, default: 2) | `3` |
+| `idleTimeoutMinutes` | Minutes before idle sandbox is stopped (optional, default: 30, staging: 10) | `15` |
 
 ### 3. Bootstrap CDK (First Time Only)
 
@@ -113,8 +121,11 @@ npx cdk deploy --all \
 2. Monitoring (main region) - independent, creates S3 data bucket
 3. Security (main region) - depends on Network, Monitoring
 4. Database (main region) - depends on Network, Security
-5. Compute (main region) - depends on Network, Security, Monitoring, Database
-6. Edge (us-east-1) - depends on Compute
+5. UserConfig (main region) - depends on Security, Monitoring
+6. Cluster (main region) - shared ECS cluster + Cloud Map namespace
+7. Sandbox (main region) - depends on Network, Monitoring, Cluster
+8. Compute (main region) - depends on all above
+9. Edge (us-east-1) - depends on Compute, Auth
 
 ### 6. Access OpenHands
 
@@ -129,16 +140,19 @@ https://<subdomain>.<domain-name>
 |-------|--------|-------------|
 | `OpenHands-Auth` | us-east-1 | Cognito User Pool + Managed Login v2 branding |
 | `OpenHands-Network` | Main | VPC import, VPC Endpoints |
-| `OpenHands-Monitoring` | Main | CloudWatch Logs, Alarms, Dashboard, Backup, S3 Data Bucket |
-| `OpenHands-Security` | Main | IAM Roles, Security Groups |
+| `OpenHands-Monitoring` | Main | CloudWatch Logs, Alarms, S3 Data Bucket, Backup |
+| `OpenHands-Security` | Main | IAM Roles, Security Groups, KMS key |
 | `OpenHands-Database` | Main | Aurora Serverless v2 PostgreSQL with RDS Proxy |
-| `OpenHands-Compute` | Main | EC2 ASG, Launch Template, Internal ALB |
-| `OpenHands-Edge-*` | us-east-1 | Lambda@Edge, CloudFront (VPC Origin), WAF, Route 53 (per domain/environment) |
+| `OpenHands-UserConfig` | Main | User Configuration API Lambda (MCP, Secrets, Integrations) |
+| `OpenHands-Cluster` | Main | Shared ECS Cluster + Cloud Map namespace |
+| `OpenHands-Sandbox` | Main | Sandbox Fargate tasks, DynamoDB registry, Orchestrator Lambda |
+| `OpenHands-Compute` | Main | Fargate services (App + OpenResty), ALB, EFS |
+| `OpenHands-Edge-*` | us-east-1 | Lambda@Edge, CloudFront, WAF, Route 53 (per domain/environment) |
 
 **Notes**:
 - Cognito is provisioned in `OpenHands-Auth` so multiple Edge stacks can reuse a single user pool/client.
 - To add another domain/environment, include it in `authCallbackDomains`, deploy `OpenHands-Auth`, then deploy a new `OpenHands-Edge-<edgeStackSuffix>`.
-- The Database stack is **required** for self-healing architecture - it persists conversation history across EC2 instance replacements.
+- The Database stack is **required** for self-healing architecture - it persists conversation history across Fargate task replacements.
 
 ## Multi-Domain Deployment
 
@@ -172,7 +186,7 @@ You can deploy multiple OpenHands instances on different domains, all sharing th
                            ┌─────────────────────────────────────┐
                            │     ComputeStack (main region)      │
                            │  - ALB with origin verification     │
-                           │  - EC2 ASG                          │
+                           │  - Fargate services (App+OpenResty) │
                            │  - SSM parameters in us-east-1      │
                            └─────────────────────────────────────┘
                                               │
@@ -205,7 +219,9 @@ npx cdk deploy OpenHands-Auth \
 Deploy the shared backend infrastructure (only once):
 
 ```bash
-npx cdk deploy OpenHands-Network OpenHands-Monitoring OpenHands-Security OpenHands-Database OpenHands-UserConfig OpenHands-Compute \
+npx cdk deploy OpenHands-Network OpenHands-Monitoring OpenHands-Security \
+  OpenHands-Database OpenHands-UserConfig OpenHands-Cluster \
+  OpenHands-Sandbox OpenHands-Compute \
   --context vpcId=<vpc-id> \
   --context hostedZoneId=<primary-hosted-zone-id> \
   --context domainName=<primary-domain> \
@@ -288,21 +304,24 @@ To remove a domain:
 
 ## Cost Estimate
 
-### Base Infrastructure (~$375-420/month)
+### Base Infrastructure (~$350-450/month)
 
 | Component | Monthly Cost (USD) | Usage Assumption |
 |-----------|--------------------|------------------|
-| EC2 m7g.xlarge Graviton | ~$112 | 730 hours (24/7) |
-| EBS gp3 300GB | ~$30 | 300GB storage |
+| Fargate App Service (4 vCPU / 8 GB ARM64) | ~$120 | 730 hours (24/7) |
+| Fargate OpenResty Service (0.25 vCPU / 512 MB) | ~$8 | 730 hours (24/7) |
+| Fargate Sandbox Tasks | ~$0-50 | On-demand, per-conversation |
 | Aurora Serverless v2 | ~$43-80 | 0.5-4 ACU (scales with usage) |
 | RDS Proxy | ~$18 | 730 hours |
+| EFS | ~$1-10 | Per-conversation workspace storage |
 | S3 Data Bucket | ~$1-5 | Depends on usage |
 | NAT Gateway | ~$0-35 | Depends on traffic |
 | CloudFront | ~$85 | 1TB data transfer |
 | ALB | ~$25 | 730 hours + LCUs |
-| VPC Endpoints (8) | ~$50 | 8 endpoints × 730 hours |
-| CloudWatch | ~$5 | Logs, metrics, alarms |
+| VPC Endpoints (10) | ~$60 | 10 endpoints × 730 hours |
+| CloudWatch | ~$5 | Logs, metrics, Container Insights |
 | Route 53 | ~$1 | 1 hosted zone + queries |
+| DynamoDB (Sandbox Registry) | ~$1 | On-demand, low traffic |
 
 ### Bedrock Usage (Variable)
 
@@ -327,14 +346,16 @@ Your existing VPC must have:
 
 ## Data Persistence
 
-OpenHands data is stored durably for self-healing across instance replacements:
+OpenHands data is stored durably for self-healing across Fargate task replacements:
 
 | Data Type | Storage | Persistence |
 |-----------|---------|-------------|
 | Conversation Metadata | Aurora PostgreSQL | Permanent (via RDS Proxy) |
-| Conversation Events | S3 | Permanent (survives instance replacement) |
-| User Settings | S3 | Permanent |
-| Workspace Files | EFS | Persistent (survives instance replacement) |
+| Conversation Events | S3 | Permanent (survives task replacement) |
+| User Settings / Secrets | S3 | Permanent (KMS envelope encryption) |
+| Workspace Files | EFS | Persistent (per-conversation access points) |
+| SDK Conversation Cache | EFS | Persistent (enables LLM context restoration) |
+| Sandbox Registry | DynamoDB | Permanent (task state, user ownership) |
 
 **Aurora Serverless v2 with RDS Proxy**:
 - PostgreSQL 15.8 with RDS Proxy for connection pooling
@@ -360,13 +381,13 @@ OpenHands data is stored durably for self-healing across instance replacements:
 
 ### Conversation Resume (Self-Healing)
 
-When EC2 instances are replaced (ASG scaling, CDK deployment, health check failure), sandbox Docker containers are terminated. OpenHands marks these conversations as `ARCHIVED` because the sandbox is missing. However, all conversation data is preserved:
+When sandbox Fargate tasks stop (idle timeout, crash, or deployment), conversations become `ARCHIVED`. All conversation data is preserved:
 
-| Data | Storage | Survives EC2 Replacement |
-|------|---------|--------------------------|
+| Data | Storage | Survives Task Stop |
+|------|---------|-------------------|
 | Conversation metadata | Aurora PostgreSQL | ✅ Yes |
 | Conversation events/history | S3 | ✅ Yes |
-| Workspace files | EFS (`/data/openhands`) | ✅ Yes |
+| Workspace files | EFS (per-conversation access point) | ✅ Yes |
 
 **Auto-Resume Flow**:
 
@@ -377,10 +398,11 @@ Frontend detects ARCHIVED status
     ↓
 Calls POST /api/v1/app-conversations/{id}/resume
     ↓
-Backend recreates sandbox container with:
-  - Same conversation ID
-  - user_id label (for authorization)
-  - EFS workspace mounted
+App → Orchestrator Lambda:
+  - Creates new EFS access point for conversation
+  - Registers new task definition with access point
+  - Launches Fargate sandbox task
+  - Updates DynamoDB registry
     ↓
 Page reloads → conversation is usable again
 ```
@@ -388,11 +410,11 @@ Page reloads → conversation is usable again
 **What happens automatically**:
 1. User navigates to an archived conversation
 2. Frontend patch detects `status: ARCHIVED` and triggers resume
-3. Backend creates a new sandbox container with the original workspace
-4. Container gets `user_id` label for runtime URL authorization
+3. Orchestrator creates a new EFS access point rooted at `/sandbox-workspace/<conversation_id>/`
+4. New Fargate sandbox task launches with the workspace mounted at `/mnt/efs/`
 5. Page reloads and conversation is ready for use
 
-**Note**: The workspace files on EFS are preserved, so any code or files created in the previous session are still available after resume.
+**Note**: The workspace files on EFS are preserved via the access point, so any code or files created in the previous session are still available after resume.
 
 ## Session Management
 
@@ -436,11 +458,11 @@ CloudFront (matches *.runtime.* wildcard certificate)
     ↓
 Lambda@Edge (viewer-request: parse subdomain, rewrite URI to /runtime/{convId}/{port}/...)
     ↓
-ALB → EC2 → OpenResty
+ALB → OpenResty (Fargate service)
     ↓
-Lua Docker Discovery (find container by convId, route to container IP:port)
+Sandbox Discovery (DynamoDB lookup by convId → Fargate task IP:port, verify user ownership)
     ↓
-User App (Flask/Node.js/etc. inside sandbox container)
+User App (Flask/Node.js/etc. inside sandbox Fargate task)
 ```
 
 ### Security Considerations
@@ -522,21 +544,24 @@ Regardless of what you configure in the policy file, the following actions are *
 
 ### How It Works
 
-1. **IAM Role**: SecurityStack creates `OpenHandsSandboxRole` with your custom policy + explicit denies
-2. **Credential Refresh**: A systemd timer on EC2 refreshes temporary credentials every 10 minutes (15-minute token lifetime)
-3. **Credential Mount**: The credentials file is mounted read-only into sandbox containers at `/data/sandbox-credentials`
-4. **AWS CLI**: The agent-server container includes AWS CLI v2, configured to use the mounted credentials
+1. **IAM Role**: SandboxStack creates a sandbox task role with your custom policy + explicit denies
+2. **Task Role Assignment**: Sandbox Fargate tasks are launched with the scoped IAM role attached directly
+3. **ECS Task Role Credentials**: AWS SDK and CLI in the sandbox container automatically use the task role credentials via the ECS credential provider (no manual credential refresh needed)
+4. **AWS CLI**: The agent-server container includes AWS CLI v2, which automatically uses the Fargate task role
 
 ## Security
 
-- EC2 instances in private subnets only
+- Fargate tasks in private subnets only
+- Per-conversation EFS isolation via access points (no cross-conversation access)
 - All AWS service access via VPC Endpoints
-- IAM Role with least privilege (Bedrock, Logs, SSM, S3, Secrets Manager)
+- IAM Roles with least privilege for each service (App, Sandbox, Orchestrator)
 - Database credentials stored in AWS Secrets Manager
 - RDS Proxy with TLS-encrypted connections
+- User secrets protected by KMS envelope encryption
 - Cognito authentication for all requests (30-day session)
+- Lambda@Edge header spoofing prevention (clears & re-injects verified user headers)
 - WAF protection with rate limiting
-- EBS, S3, and Aurora storage encryption enabled
+- S3 and Aurora storage encryption enabled
 
 ## Useful Commands
 
@@ -568,8 +593,8 @@ Ensure the VPC exists and your AWS credentials have `ec2:DescribeVpcs` permissio
 ### Certificate Validation Pending
 ACM certificates use DNS validation. Ensure the Hosted Zone is correctly configured.
 
-### EC2 Instance Not Starting
-Check CloudWatch Logs at `/openhands/application` for container startup errors.
+### Fargate Task Not Starting
+Check CloudWatch Logs at `/openhands/application` for container startup errors. Check ECS service events for Fargate capacity issues.
 
 ## CI/CD
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,51 @@
 # Architecture Deep Dive
 
-This document provides detailed technical knowledge about the authentication, database, and conversation storage systems that enable self-healing across EC2 instance replacements.
+This document provides detailed technical knowledge about the authentication, database, sandbox orchestration, and conversation storage systems that enable self-healing across ECS Fargate task replacements.
+
+## Architecture Overview (10 Stacks)
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           us-east-1                                      │
+│  ┌──────────────────────────────────────────────────────────────────┐   │
+│  │ AuthStack: Cognito User Pool, managed login branding             │   │
+│  └──────────────────────────────────────────────────────────────────┘   │
+│                                    │                                     │
+│  ┌──────────────────────────────────────────────────────────────────┐   │
+│  │ EdgeStack: Lambda@Edge, CloudFront, WAF, Route 53                │   │
+│  └──────────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼ (HTTP Origin)
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           Main Region                                    │
+│                                                                          │
+│  ┌───────────────┐    ┌────────────────┐    ┌──────────────────┐        │
+│  │ NetworkStack  │───▶│ SecurityStack  │───▶│ MonitoringStack  │        │
+│  │ VPC, Endpoints│    │ Fargate roles  │    │ Logs, S3, Alarms │        │
+│  └───────────────┘    │ SGs, KMS       │    └──────────────────┘        │
+│         │             └────────────────┘           │                    │
+│         │                    │                      │                    │
+│         ▼                    ▼                      │                    │
+│  ┌──────────────┐  ┌───────────────────────┐       │                    │
+│  │ ClusterStack │  │    DatabaseStack       │       │                    │
+│  │ ECS Cluster  │  │  Aurora Serverless v2  │       │                    │
+│  │ Cloud Map    │  │  RDS Proxy             │       │                    │
+│  └──────────────┘  └───────────────────────┘       │                    │
+│         │                   │                      │                    │
+│         ├──────▶ ┌──────────────────────────────────────┐              │
+│         │        │           SandboxStack                │              │
+│         │        │  DynamoDB, Orchestrator, Sandbox Tasks │              │
+│         │        │  Idle Monitor, Task State Lambda       │              │
+│         │        └──────────────────────────────────────┘              │
+│         │                   │                                           │
+│         ▼                   ▼                                           │
+│  ┌─────────────────────────────────────────────────────────────────┐    │
+│  │                      ComputeStack                                │    │
+│  │   Fargate Services (App + OpenResty), ALB, EFS, Lambda TG       │    │
+│  └─────────────────────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────────────────────┘
+```
 
 ## Authentication System
 
@@ -15,7 +60,7 @@ Lambda@Edge (JWT Validation)
     ↓ (if valid)
 Inject User Headers (X-Cognito-*)
     ↓
-Origin (ALB → EC2)
+Origin (ALB → Fargate)
     ↓
 OpenHands App (CognitoUserAuth)
 ```
@@ -35,17 +80,19 @@ OpenHands App (CognitoUserAuth)
 
 ### Lambda@Edge Authentication Flows
 
-Three authentication flows handled by `lib/lambda-edge/auth-handler.js`:
+Four authentication flows handled by `lib/lambda-edge/auth-handler.js`:
 
 1. **OAuth Callback (`/_callback`)**: Receives auth code → exchanges for tokens → verifies ID token signature via JWKS → sets `id_token` cookie (HttpOnly, Secure, SameSite=Lax) → redirects to destination
 
 2. **Logout (`/_logout`)**: Clears `id_token` cookie → redirects to Cognito logout URL
 
-3. **Request Validation**: Extracts `id_token` from cookie → verifies JWT signature against Cognito JWKS → validates issuer, expiration, audience → **injects user headers** → redirects to login if invalid
+3. **Runtime Subdomain**: Verify JWT → inject `X-Cognito-User-Id` → rewrite URI to `/runtime/{convId}/{port}/...` → allow/redirect
+
+4. **Main Domain Request Validation**: Extracts `id_token` from cookie → verifies JWT signature against Cognito JWKS → validates issuer, expiration, audience → **injects user headers** → redirects to login if invalid
 
 ### User Header Injection
 
-**Critical for conversation persistence**: Lambda@Edge injects verified user information into request headers, clearing any existing headers to prevent spoofing:
+**Critical for conversation persistence and multi-tenant isolation**: Lambda@Edge injects verified user information into request headers, clearing any existing headers to prevent spoofing:
 
 - `X-Cognito-User-Id`: Cognito user ID (UUID from `payload.sub`)
 - `X-Cognito-Email`: User's email address
@@ -71,59 +118,93 @@ USER_AUTH_CLASS=openhands.server.user_auth.cognito_user_auth.CognitoUserAuth
 
 | Setting | Value | Notes |
 |---------|-------|-------|
-| Engine | PostgreSQL 15.4 | Aurora Serverless v2 |
+| Engine | PostgreSQL 15.8 | Aurora Serverless v2 |
 | Min ACU | 0.5 | ~$43/month minimum |
 | Max ACU | 4 | Auto-scales with usage |
-| IAM Auth | Enabled | No passwords required |
+| IAM Auth | Enabled (backup) | For direct cluster admin access |
 | Encryption | Yes | At-rest encryption |
 | Backup | 35 days | Automatic daily backups |
 | Removal Policy | SNAPSHOT | Creates backup on deletion |
 
-### IAM Database Authentication
+### Database Authentication
 
-**Why IAM Auth?**
-- No passwords to store, rotate, or manage
-- EC2 uses its IAM role for authentication
-- Tokens expire after 15 minutes (auto-refreshed)
-- Audit trail via CloudTrail
+**Primary: RDS Proxy with Password Auth**
 
-**Token Generation Flow**:
-1. **Systemd Timer**: Runs every 10 minutes
-2. **Token Script**: `/usr/local/bin/refresh-db-token.sh`
-3. **AWS CLI**: `aws rds generate-db-auth-token`
-4. **Output**: `/data/openhands/config/database.env`
+The application connects through RDS Proxy using password-based authentication via Secrets Manager:
 
-### Database User Setup (One-Time)
+1. **DatabaseStack** creates a proxy user with credentials stored in Secrets Manager (`openhands/database/proxy-user`)
+2. **RDS Proxy** handles connection pooling and credential rotation
+3. **Fargate App Service** receives the DB password via ECS native secret injection
+4. No token refresh needed — RDS Proxy manages connection lifecycle
 
-After first deployment, create the IAM database user in PostgreSQL:
+**Backup: IAM Authentication**
 
-```sql
--- Create the IAM authentication user
-CREATE USER openhands_iam;
-GRANT rds_iam TO openhands_iam;
+IAM auth is also enabled on the cluster for direct admin access:
+- Used by the DB bootstrap Lambda (custom resource) for one-time setup
+- Can be used for manual admin tasks via `aws rds generate-db-auth-token`
 
--- Grant database-level permissions
-GRANT ALL PRIVILEGES ON DATABASE openhands TO openhands_iam;
+### Database Bootstrap (Automated)
 
--- Grant schema-level permissions
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO openhands_iam;
-GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO openhands_iam;
+The `db-bootstrap` Lambda function (custom resource) automatically runs on first deployment:
+- Creates the proxy user with appropriate permissions
+- Grants schema-level permissions for future tables
+- No manual SQL setup required
 
--- Set default privileges for future tables
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO openhands_iam;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO openhands_iam;
+## Sandbox Orchestration
+
+### Architecture
+
 ```
+App Service → Orchestrator Lambda (via Cloud Map DNS)
+                     ↓
+              DynamoDB Registry ← EventBridge (idle monitor, task state)
+                     ↓
+              ECS Fargate Tasks (per-conversation sandbox)
+                     ↓
+              EFS Access Points (per-conversation isolation)
+```
+
+### Sandbox Lifecycle
+
+| Action | Trigger | What Happens |
+|--------|---------|-------------|
+| **Start** | User creates conversation | Orchestrator: create EFS AP → register task def → RunTask → update DynamoDB |
+| **Resume** | User resumes archived conversation | Same as Start (AP may already exist) |
+| **Stop** | User stops conversation | Orchestrator: StopTask → cleanup AP |
+| **Idle Timeout** | EventBridge (5-min schedule) | Idle Monitor Lambda: detect stale tasks → StopTask → delete AP |
+| **Task Crash** | ECS task state change event | Task State Lambda: update DynamoDB → delete AP |
+
+### DynamoDB Sandbox Registry
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `conversation_id` | PK | Conversation UUID |
+| `user_id` | GSI | For user-scoped queries |
+| `status` | GSI | RUNNING, STOPPED, etc. |
+| `task_arn` | String | ECS Fargate task ARN |
+| `access_point_id` | String | EFS access point ID |
+| `task_definition_arn` | String | Per-conversation task def |
+| `last_activity_at` | Number | Unix timestamp for idle detection |
+
+### Per-Conversation EFS Isolation
+
+Each sandbox mounts an EFS access point rooted at `/sandbox-workspace/<conversation_id>/`:
+- Container sees `/mnt/efs/` = access point root (cannot traverse to parent/sibling directories)
+- Workspace files at `/mnt/efs/workspace/` persist across task restarts
+- SDK conversation cache at `/mnt/efs/<CID_hex>/events/` enables LLM context restoration
 
 ## Conversation Storage
 
 ### Storage Locations
 
-| Data Type | Storage | Persistence | Notes |
-|-----------|---------|-------------|-------|
-| Conversation Metadata | Aurora PostgreSQL | Permanent | User ID, title, timestamps |
-| Conversation Events | S3 | Permanent | Agent actions, tool outputs |
-| User Settings | S3 | Permanent | LLM config, preferences |
-| Workspace Files | EFS | Persistent | Code, project files (`/data/openhands/workspace`) |
+| Data Type | Storage | Written By | Persistence |
+|-----------|---------|-----------|-------------|
+| Conversation Metadata | Aurora PostgreSQL | App server | Permanent |
+| Conversation Events | S3 (`FILE_STORE=s3`) | App server | Permanent (authority for UI) |
+| User Settings / Secrets | S3 | App server | Permanent (KMS encrypted) |
+| Workspace Files | EFS | Sandbox agent-server | Persistent (per-conversation AP) |
+| SDK Conversation Cache | EFS | Sandbox SDK | Persistent (LLM context restoration) |
+| Sandbox State | DynamoDB | Orchestrator | Permanent (task registry) |
 
 ### Storage Path Logic
 
@@ -150,16 +231,15 @@ def get_conversation_dir(sid, user_id=None):
 
 ## Self-Healing Data Flow
 
-When a new EC2 instance launches:
+When a Fargate task is replaced (deployment, scaling, health check failure):
 
-1. **User Data Script** runs:
-   - Installs Docker, CloudWatch Agent
-   - Formats fresh EBS volume
-   - Generates IAM auth token for Aurora
-   - Starts OpenHands container
+1. **ECS Service** launches new task:
+   - Fargate pulls container images from ECR
+   - Mounts EFS app workspace at `/data/openhands`
+   - Injects secrets via ECS native secret injection (DB password, sandbox secret key)
 
-2. **OpenHands Startup**:
-   - Connects to Aurora (IAM auth)
+2. **OpenHands App Startup**:
+   - Connects to Aurora via RDS Proxy (password auth, no token refresh)
    - Loads existing conversation metadata
    - Connects to S3 for conversation events
 
@@ -169,23 +249,29 @@ When a new EC2 instance launches:
    - OpenHands retrieves user's conversations from Aurora
    - User sees all previous conversations
 
+4. **Sandbox Resume**:
+   - When user accesses an archived conversation, orchestrator creates new sandbox task
+   - EFS access point preserves workspace files from previous session
+   - SDK conversation cache enables LLM context restoration
+
 ### Testing Self-Healing
 
 ```bash
 # 1. Create a conversation in the application
 
-# 2. Force instance replacement
-aws autoscaling terminate-instance-in-auto-scaling-group \
-  --instance-id <instance-id> \
-  --should-decrement-desired-capacity false \
+# 2. Force Fargate app service redeployment
+aws ecs update-service --cluster <cluster-name> \
+  --service openhands-app --force-new-deployment \
   --region <region>
 
-# 3. Wait for new instance (5-10 minutes)
-watch -n 10 "aws autoscaling describe-auto-scaling-groups \
-  --query 'AutoScalingGroups[0].Instances[*].[InstanceId,HealthStatus]' \
-  --output table"
+# 3. Wait for new task to stabilize (2-5 minutes)
+aws ecs describe-services --cluster <cluster-name> \
+  --services openhands-app \
+  --query 'services[0].{running:runningCount,desired:desiredCount,pending:pendingCount}' \
+  --region <region>
 
 # 4. Verify conversations persist
 # - Log in to application
 # - Previous conversations should be visible
+# - Resume an archived conversation to verify workspace files persist
 ```

--- a/test/E2E_TEST_CASES.md
+++ b/test/E2E_TEST_CASES.md
@@ -6,7 +6,7 @@ This document defines the end-to-end test cases for validating the OpenHands inf
 
 - AWS CLI configured with appropriate credentials
 - Chrome browser with DevTools MCP server connected
-- Node.js 20+ installed
+- Node.js 22+ installed
 - CDK bootstrapped in deployment regions
 
 ## Important: Browser Tab Cleanup
@@ -79,7 +79,7 @@ Deploy all OpenHands CDK stacks to the target AWS region.
 
 | # | Criteria | Verification |
 |---|----------|--------------|
-| 1 | All 6 stacks deploy successfully | `cdk deploy` exits with code 0 |
+| 1 | All 10 stacks deploy successfully | `cdk deploy` exits with code 0 |
 | 2 | No CloudFormation rollbacks | Check AWS Console for stack status |
 | 3 | CloudFront distribution is deployed | `aws cloudfront get-distribution --id <dist-id>` shows "Deployed" |
 | 4 | ACM certificate is issued | `aws acm describe-certificate` shows status "ISSUED" |


### PR DESCRIPTION
## Summary

- Comprehensively update all documentation (README.md, ARCHITECTURE.md, CLAUDE.md, E2E_TEST_CASES.md) to reflect the current ECS Fargate architecture
- Address 20+ outdated references from the EC2/ASG era that were missed during the Fargate migration

## Key Documentation Changes

### Architecture Updates
- **Architecture diagrams**: EC2 ASG → Fargate services + sandbox orchestration flow
- **Stack structure**: 7 stacks → 10 stacks (added ClusterStack, SandboxStack, UserConfigStack)
- **Compute**: m7g.xlarge Graviton → Fargate ARM64 services (App 4 vCPU/8 GB, OpenResty 0.25 vCPU/512 MB)
- **Runtime routing**: Docker container discovery → DynamoDB sandbox registry lookup

### Storage & Persistence
- **Workspace storage**: shared EFS `/data/openhands` → per-conversation EFS access points at `/sandbox-workspace/<CID>/`
- **Self-healing**: EC2 instance replacement → Fargate task replacement with orchestrator-managed resume flow

### Security & Auth
- **Sandbox AWS access**: systemd timer credential refresh → Fargate task role (automatic ECS credential provider)
- **Database auth**: IAM token refresh via systemd timer → RDS Proxy password auth via Secrets Manager
- **DB bootstrap**: manual SQL setup → automated db-bootstrap Lambda custom resource
- **Security**: EC2 private subnets → Fargate + per-conversation EFS isolation

### Infrastructure
- **Cost estimate**: EC2/EBS pricing → Fargate/DynamoDB/EFS pricing
- **Context parameters**: documented `skipS3Endpoint`, `warmPoolSize`, `idleTimeoutMinutes`
- **Key files**: added sandbox-monitor, sandbox-task-state, db-bootstrap Lambda entries
- **Prerequisites**: Node.js 20+ → 22+ (matches package.json engines)
- **E2E tests**: TC-001 acceptance criteria 6 stacks → 10 stacks

### ARCHITECTURE.md (major rewrite)
- Added sandbox orchestration section (lifecycle, DynamoDB schema, EFS isolation)
- Updated database section (PostgreSQL 15.4 → 15.8, RDS Proxy password auth, automated bootstrap)
- Rewrote self-healing section for Fargate architecture
- Added architecture overview diagram matching actual stack structure

## Test plan

- [x] Build passes (`npm run build`)
- [ ] CI checks pass
- [ ] Reviewer bot findings addressed

## Checklist

- [x] No new unit tests needed (docs-only change)
- [x] Documentation updated
- [x] No sensitive data in changes (verified with grep)