### PR TITLE
fix(network): add skip parameters for DynamoDB and interface VPC endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,8 @@ npx cdk diff --all --context ...
 ### Optional Context Parameters
 
 - `skipS3Endpoint` - Skip S3 Gateway endpoint if VPC already has one
+- `skipDynamoDbEndpoint` - Skip DynamoDB Gateway endpoint if VPC already has one
+- `skipInterfaceEndpoints` - Interface endpoint IDs to skip (JSON array, e.g., `'["Ecs","EcsTelemetry"]'`)
 - `sandboxAwsAccess` - Enable sandbox AWS access (default: false)
 - `sandboxAwsPolicyFile` - Path to custom IAM policy for sandbox
 - `warmPoolSize` - Pre-warmed sandbox Fargate tasks (default: 2)

--- a/bin/openhands-infra.ts
+++ b/bin/openhands-infra.ts
@@ -124,6 +124,11 @@ const edgeStackId = edgeStackSuffix
 
 const skipS3Endpoint = app.node.tryGetContext('skipS3Endpoint') === 'true' ||
   app.node.tryGetContext('skipS3Endpoint') === true;
+const skipDynamoDbEndpoint = app.node.tryGetContext('skipDynamoDbEndpoint') === 'true' ||
+  app.node.tryGetContext('skipDynamoDbEndpoint') === true;
+const skipInterfaceEndpoints = parseDomainList(
+  app.node.tryGetContext('skipInterfaceEndpoints'), []
+);
 
 // Sandbox AWS access configuration
 const sandboxAwsAccess = app.node.tryGetContext('sandboxAwsAccess') === 'true' ||
@@ -159,6 +164,8 @@ const networkStack = new NetworkStack(app, `${prefix}-Network`, {
   env: mainEnv,
   config,
   skipS3Endpoint,
+  skipDynamoDbEndpoint,
+  skipInterfaceEndpoints,
   description: 'OpenHands Network Infrastructure - VPC Endpoints',
   crossRegionReferences: true,
 });

--- a/lib/network-stack.ts
+++ b/lib/network-stack.ts
@@ -10,6 +10,16 @@ export interface NetworkStackProps extends cdk.StackProps {
    * Set to true when deploying to a VPC that already has an S3 endpoint.
    */
   skipS3Endpoint?: boolean;
+  /**
+   * Skip creating DynamoDB VPC Gateway Endpoint if one already exists in the VPC.
+   * Set to true when deploying to a VPC that already has a DynamoDB endpoint.
+   */
+  skipDynamoDbEndpoint?: boolean;
+  /**
+   * Interface endpoint IDs to skip (e.g., ['Ecs', 'EcsTelemetry']).
+   * Use when the VPC has conflicting DNS entries from existing endpoints.
+   */
+  skipInterfaceEndpoints?: string[];
 }
 
 /**
@@ -59,7 +69,9 @@ export class NetworkStack extends cdk.Stack {
       { id: 'EcsTelemetry', service: ec2.InterfaceVpcEndpointAwsService.ECS_TELEMETRY },
     ];
 
+    const skipSet = new Set(props.skipInterfaceEndpoints ?? []);
     for (const endpoint of interfaceEndpoints) {
+      if (skipSet.has(endpoint.id)) continue;
       new ec2.InterfaceVpcEndpoint(this, `${endpoint.id}Endpoint`, {
         vpc,
         service: endpoint.service,
@@ -77,10 +89,12 @@ export class NetworkStack extends cdk.Stack {
     }
 
     // DynamoDB Gateway Endpoint (free, used by sandbox registry)
-    new ec2.GatewayVpcEndpoint(this, 'DynamoDbEndpoint', {
-      vpc,
-      service: ec2.GatewayVpcEndpointAwsService.DYNAMODB,
-    });
+    if (!props.skipDynamoDbEndpoint) {
+      new ec2.GatewayVpcEndpoint(this, 'DynamoDbEndpoint', {
+        vpc,
+        service: ec2.GatewayVpcEndpointAwsService.DYNAMODB,
+      });
+    }
 
     // Store outputs
     this.output = {

--- a/test/stacks.test.ts
+++ b/test/stacks.test.ts
@@ -93,6 +93,36 @@ describe('OpenHands Infrastructure Stacks', () => {
       });
     });
 
+    test('skips DynamoDB endpoint when skipDynamoDbEndpoint is true', () => {
+      const stack = new NetworkStack(app, 'TestNetworkSkipDynamo', {
+        env: testEnv,
+        config: testConfig,
+        skipDynamoDbEndpoint: true,
+      });
+
+      const template = Template.fromStack(stack);
+      const gateways = template.findResources('AWS::EC2::VPCEndpoint', {
+        Properties: { VpcEndpointType: 'Gateway' },
+      });
+      // Only S3 gateway should remain (DynamoDB skipped)
+      expect(Object.keys(gateways)).toHaveLength(1);
+    });
+
+    test('skips specified interface endpoints', () => {
+      const stack = new NetworkStack(app, 'TestNetworkSkipInterface', {
+        env: testEnv,
+        config: testConfig,
+        skipInterfaceEndpoints: ['Ecs', 'EcsTelemetry'],
+      });
+
+      const template = Template.fromStack(stack);
+      const interfaces = template.findResources('AWS::EC2::VPCEndpoint', {
+        Properties: { VpcEndpointType: 'Interface' },
+      });
+      // 10 total interface endpoints minus 2 skipped = 8
+      expect(Object.keys(interfaces)).toHaveLength(8);
+    });
+
     test('matches snapshot', () => {
       const stack = new NetworkStack(app, 'TestNetworkStack', {
         env: testEnv,


### PR DESCRIPTION
## Summary

- Add `skipDynamoDbEndpoint` context parameter to skip DynamoDB Gateway endpoint creation (same pattern as existing `skipS3Endpoint`)
- Add `skipInterfaceEndpoints` context parameter to skip specific interface endpoints by ID (e.g., `["Ecs","EcsTelemetry"]`)
- Fixes production deployment failure where pre-existing VPC endpoints conflict with CDK-managed ones

## Context

Production VPC (ap-southeast-1) has pre-existing DynamoDB Gateway endpoint and conflicting DNS entries for ECS services, causing NetworkStack deployment to fail with `AlreadyExists` and `conflicting DNS domain` errors.

## Test plan

- [x] Build passes (`npm run build`)
- [x] Unit tests pass (`npm run test`) — 106 tests, 2 new
- [ ] CI checks pass
- [ ] Reviewer bot findings addressed
- [ ] Deployed to staging
- [ ] E2E tests pass
  - [ ] TC-003: Login
  - [ ] TC-004: Conversation List
  - [ ] TC-005: New Conversation

## Checklist

- [x] New unit tests written for new functionality
- [x] Documentation updated (CLAUDE.md optional params)