### PR TITLE
fix(sandbox): grant Bedrock model access on sandbox task role

### DIFF
--- a/lib/sandbox-stack.ts
+++ b/lib/sandbox-stack.ts
@@ -209,6 +209,26 @@ export class SandboxStack extends cdk.Stack {
       },
     }));
 
+    // Bedrock access for LLM inference (ALWAYS granted — required for agent-server LLM calls)
+    // Covers 1P (Amazon), Anthropic Claude, and 2P/3P models available on Bedrock.
+    // Users can select models via settings; this policy permits all Bedrock models.
+    sandboxTaskRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'BedrockModelAccess',
+      effect: iam.Effect.ALLOW,
+      actions: [
+        'bedrock:InvokeModel',
+        'bedrock:InvokeModelWithResponseStream',
+      ],
+      resources: [
+        // Foundation models — all providers (1P Amazon, Anthropic, Meta, Mistral, Cohere, AI21, etc.)
+        'arn:aws:bedrock:*::foundation-model/*',
+        // Cross-region inference profiles (global, us, eu, apac prefixes)
+        `arn:aws:bedrock:*:${this.account}:inference-profile/*`,
+        // Application inference profiles (for cost tracking per user/team)
+        `arn:aws:bedrock:${config.region}:${this.account}:application-inference-profile/*`,
+      ],
+    }));
+
     // AWS permissions for sandbox containers (gated by sandboxAwsAccess context flag)
     // Loads custom IAM policy from sandbox-aws-policy.json (same policy used by SecurityStack
     // for the STS-assumed sandbox role in Docker-on-EC2 mode)

--- a/lib/security-stack.ts
+++ b/lib/security-stack.ts
@@ -151,8 +151,9 @@ export class SecurityStack extends cdk.Stack {
       description: 'IAM task role for OpenHands Fargate app service',
     });
 
-    // Custom policy for Bedrock access
-    // Supports both foundation models (Claude 3.x) and inference profiles (Claude 4.x)
+    // Bedrock access for LLM inference
+    // Covers 1P (Amazon), Anthropic Claude, and 2P/3P models available on Bedrock.
+    // Users can select models via settings; this policy permits all Bedrock models.
     appTaskRole.addToPolicy(new iam.PolicyStatement({
       sid: 'BedrockAccess',
       effect: iam.Effect.ALLOW,
@@ -161,13 +162,12 @@ export class SecurityStack extends cdk.Stack {
         'bedrock:InvokeModelWithResponseStream',
       ],
       resources: [
-        // Foundation models (Claude 3.x and earlier)
-        'arn:aws:bedrock:*::foundation-model/anthropic.claude-*',
-        'arn:aws:bedrock:*::foundation-model/us.anthropic.claude-*',
-        // Inference profiles (Claude 4.x - Opus 4.5, Sonnet 4, etc.)
-        `arn:aws:bedrock:${config.region}:${this.account}:inference-profile/*anthropic.claude*`,
-        // Cross-region inference profiles (global prefix)
-        `arn:aws:bedrock:*:${this.account}:inference-profile/global.anthropic.claude*`,
+        // Foundation models — all providers (1P Amazon, Anthropic, Meta, Mistral, Cohere, AI21, etc.)
+        'arn:aws:bedrock:*::foundation-model/*',
+        // Cross-region inference profiles (global, us, eu, apac prefixes)
+        `arn:aws:bedrock:*:${this.account}:inference-profile/*`,
+        // Application inference profiles (for cost tracking per user/team)
+        `arn:aws:bedrock:${config.region}:${this.account}:application-inference-profile/*`,
       ],
     }));
 

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -4567,10 +4567,9 @@ exports[`OpenHands Infrastructure Stacks SecurityStack matches snapshot 1`] = `
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:bedrock:*::foundation-model/anthropic.claude-*",
-                "arn:aws:bedrock:*::foundation-model/us.anthropic.claude-*",
-                "arn:aws:bedrock:us-west-2:123456789012:inference-profile/*anthropic.claude*",
-                "arn:aws:bedrock:*:123456789012:inference-profile/global.anthropic.claude*",
+                "arn:aws:bedrock:*::foundation-model/*",
+                "arn:aws:bedrock:*:123456789012:inference-profile/*",
+                "arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/*",
               ],
               "Sid": "BedrockAccess",
             },


### PR DESCRIPTION
## Summary

The sandbox task role lacked `bedrock:InvokeModel` permission when `sandboxAwsAccess` was disabled (production). The agent-server inside the sandbox needs Bedrock access for LLM calls regardless of the `sandboxAwsAccess` flag.

**Root cause**: `sandboxAwsAccess=true` was only set in staging deploy. Production sandbox had no Bedrock permissions, causing:
```
litellm.APIConnectionError: BedrockException - User is not authorized to perform: bedrock:InvokeModel
on resource: inference-profile/global.anthropic.claude-opus-4-5-20251101-v1:0
```

**Changes**:
- Add `BedrockModelAccess` policy to sandbox task role **unconditionally** (outside `sandboxAwsAccess` gate)
- Broaden Bedrock permissions to cover **all** foundation models (1P Amazon Nova, Anthropic Claude, Meta Llama, Mistral, Cohere, AI21, etc.)
- Support cross-region inference profiles (global/us/eu/apac prefixes)
- Support application inference profiles for per-user/team cost tracking
- Apply same broadened permissions to app task role in SecurityStack

**IAM resources granted** (`InvokeModel` + `InvokeModelWithResponseStream` only):
| Resource ARN Pattern | Purpose |
|----------------------|---------|
| `arn:aws:bedrock:*::foundation-model/*` | All foundation models (all providers) |
| `arn:aws:bedrock:*:{account}:inference-profile/*` | Cross-region inference profiles |
| `arn:aws:bedrock:{region}:{account}:application-inference-profile/*` | Application inference profiles (cost tracking) |

## Test plan

- [x] Build passes (`npm run build`)
- [x] Unit tests pass (`npm run test`)
- [x] CI checks pass
- [x] Reviewer bot findings addressed (no findings)
- [x] Deployed to staging
- [x] Deployed to production
- [x] **E2E tests pass**
  - [x] TC-003: Login (staging + production)
  - [x] TC-004: Verify Conversation List (staging + production)
  - [x] TC-005: Start New Conversation (staging + production)
  - [x] TC-005a: Load Existing Conversation History (staging)
  - [x] TC-017: Sandbox Bedrock Access — **staging** (us-west-2) and **production** (ap-southeast-1) both confirmed working

## Checklist

- [x] IAM policy reviewed — actions limited to InvokeModel only
- [x] No sensitive information in source code
- [x] Snapshots updated