### PR TITLE
fix(ci): use GitHub App token in release workflow to trigger CI

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c # v2
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

The `release-prepare` workflow used the default `GITHUB_TOKEN` to push the release branch and create the PR. GitHub [suppresses events created by `GITHUB_TOKEN`](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) to prevent recursive workflows, so CI (`build-and-test`) never triggered on release PRs — causing the merge to be blocked by branch protection.

### Changes
- Add `actions/create-github-app-token@v2` step to generate a short-lived token from the configured GitHub App (`APP_ID` + `APP_PRIVATE_KEY` secrets)
- Pass the app token to `actions/checkout` so `git push` authenticates as the app
- Use the app token for `gh pr create` so the `pull_request` event fires normally

### Prerequisites
- GitHub App installed on the repository with `Contents: Read & Write` and `Pull requests: Read & Write` permissions
- Repository secrets `APP_ID` and `APP_PRIVATE_KEY` configured

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Unit tests pass (`npm run test`)
- [ ] CI checks pass
- [ ] Reviewer bot findings addressed (no new findings)
- [ ] Deployed to staging
- [ ] **E2E tests pass** (run `./test/select-e2e-tests.sh` for required tests)
  - [ ] TC-003: Login
  - [ ] TC-004: Conversation List
  - [ ] TC-005: New Conversation

## Checklist

- [x] No new unit tests needed (workflow-only change)
- [x] Documentation updated (PR description explains prerequisites)
