### PR TITLE
feat(compute): rightsize app Fargate task and add auto scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,12 +304,12 @@ To remove a domain:
 
 ## Cost Estimate
 
-### Base Infrastructure (~$350-450/month)
+### Base Infrastructure (~$250-350/month)
 
 | Component | Monthly Cost (USD) | Usage Assumption |
 |-----------|--------------------|------------------|
-| Fargate App Service (4 vCPU / 8 GB ARM64) | ~$120 | 730 hours (24/7) |
-| Fargate OpenResty Service (0.25 vCPU / 512 MB) | ~$8 | 730 hours (24/7) |
+| Fargate App Service (1 vCPU / 2 GB ARM64, auto-scales 1-3) | ~$30 | 730 hours baseline, scales on demand |
+| Fargate OpenResty Service (0.25 vCPU / 512 MB, auto-scales 1-3) | ~$8 | 730 hours baseline, scales on demand |
 | Fargate Sandbox Tasks | ~$0-50 | On-demand, per-conversation |
 | Aurora Serverless v2 | ~$43-80 | 0.5-4 ACU (scales with usage) |
 | RDS Proxy | ~$18 | 730 hours |

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -234,7 +234,7 @@ Two separate ECS Fargate services run the application:
    - Secrets: `OH_SECRET_KEY`, `DB_PASS` via ECS native injection
    - Auto Scaling: CPU >60% scale out, Memory >70% scale out
 
-2. **OpenResty Service** (`openhands-openresty`): 0.25 vCPU / 512 MB ARM64
+2. **OpenResty Service** (`openhands-openresty`): 0.25 vCPU / 512 MB ARM64 (auto-scales 1-3 tasks)
    - Runtime proxy on port 8080
    - Routes `/runtime/{convId}/{port}/...` to sandbox Fargate tasks
 

--- a/lib/compute-stack.ts
+++ b/lib/compute-stack.ts
@@ -122,7 +122,7 @@ export interface ComputeStackProps extends cdk.StackProps {
  *
  * This stack deploys:
  * - OpenHands App Fargate Service (1 vCPU, 2 GB, auto-scales 1-3) with Cloud Map DNS
- * - OpenResty Proxy Fargate Service (0.25 vCPU, 512 MB)
+ * - OpenResty Proxy Fargate Service (0.25 vCPU, 512 MB, auto-scales 1-3)
  * - Internet-facing Application Load Balancer
  * - IP-type Target Groups with health checks
  * - EFS for persistent workspace storage
@@ -625,6 +625,20 @@ export class ComputeStack extends cdk.Stack {
       propagateTags: ecs.PropagatedTagSource.TASK_DEFINITION,
     });
     cdk.Tags.of(openrestyService).add('Component', 'openresty-proxy');
+
+    // ========================================
+    // OpenResty Service Auto Scaling
+    // ========================================
+    const openrestyScaling = openrestyService.autoScaleTaskCount({
+      minCapacity: 1,
+      maxCapacity: 3,
+    });
+
+    openrestyScaling.scaleOnCpuUtilization('OpenRestyCpuScaling', {
+      targetUtilizationPercent: 60,
+      scaleInCooldown: cdk.Duration.seconds(300),
+      scaleOutCooldown: cdk.Duration.seconds(60),
+    });
 
     // ========================================
     // Internet-facing ALB

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1789,6 +1789,63 @@ security_analyzer = "llm"",
       },
       "Type": "AWS::ECS::Service",
     },
+    "OpenRestyServiceTaskCountTargetB0623215": {
+      "Properties": {
+        "MaxCapacity": 3,
+        "MinCapacity": 1,
+        "ResourceId": {
+          "Fn::Join": [
+            "",
+            [
+              "service/",
+              {
+                "Fn::ImportValue": "TestClusterStack:ExportsOutputRefClusterEB0386A796A0E3FE",
+              },
+              "/",
+              {
+                "Fn::GetAtt": [
+                  "OpenRestyService0A1011FD",
+                  "Name",
+                ],
+              },
+            ],
+          ],
+        },
+        "RoleARN": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":iam::123456789012:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService",
+            ],
+          ],
+        },
+        "ScalableDimension": "ecs:service:DesiredCount",
+        "ServiceNamespace": "ecs",
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+    },
+    "OpenRestyServiceTaskCountTargetOpenRestyCpuScalingD94C5709": {
+      "Properties": {
+        "PolicyName": "TestComputeStackOpenRestyServiceTaskCountTargetOpenRestyCpuScalingFC5822BF",
+        "PolicyType": "TargetTrackingScaling",
+        "ScalingTargetId": {
+          "Ref": "OpenRestyServiceTaskCountTargetB0623215",
+        },
+        "TargetTrackingScalingPolicyConfiguration": {
+          "PredefinedMetricSpecification": {
+            "PredefinedMetricType": "ECSServiceAverageCPUUtilization",
+          },
+          "ScaleInCooldown": 300,
+          "ScaleOutCooldown": 60,
+          "TargetValue": 60,
+        },
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+    },
     "OpenRestyTaskDef8DEC8161": {
       "Properties": {
         "ContainerDefinitions": [

--- a/test/stacks.test.ts
+++ b/test/stacks.test.ts
@@ -396,14 +396,10 @@ describe('OpenHands Infrastructure Stacks', () => {
       // Verify CloudWatch Alarms are created (CPU + Memory for ECS)
       template.resourceCountIs('AWS::CloudWatch::Alarm', 2);
 
-      // Verify App Service Auto Scaling is configured
-      template.hasResourceProperties('AWS::ApplicationAutoScaling::ScalableTarget', {
-        MinCapacity: 1,
-        MaxCapacity: 3,
-        ScalableDimension: 'ecs:service:DesiredCount',
-      });
+      // Verify Auto Scaling is configured for both services (2 ScalableTargets)
+      template.resourceCountIs('AWS::ApplicationAutoScaling::ScalableTarget', 2);
 
-      // Verify CPU-based scaling policy
+      // Verify CPU-based scaling policy (both App and OpenResty)
       template.hasResourceProperties('AWS::ApplicationAutoScaling::ScalingPolicy', {
         PolicyType: 'TargetTrackingScaling',
         TargetTrackingScalingPolicyConfiguration: {
@@ -414,7 +410,7 @@ describe('OpenHands Infrastructure Stacks', () => {
         },
       });
 
-      // Verify Memory-based scaling policy
+      // Verify Memory-based scaling policy (App only)
       template.hasResourceProperties('AWS::ApplicationAutoScaling::ScalingPolicy', {
         PolicyType: 'TargetTrackingScaling',
         TargetTrackingScalingPolicyConfiguration: {


### PR DESCRIPTION
## Summary

- Reduce app Fargate service from **4 vCPU / 8 GB** to **1 vCPU / 2 GB** based on actual CloudWatch metrics
- Add **target tracking auto scaling** (1-3 tasks) for both App and OpenResty services
- Update README.md cost estimates to reflect new sizing
- ~75% reduction in baseline Fargate cost

### Motivation

CloudWatch metrics (7-day analysis, staging environment) show the app server is massively over-provisioned:

| Metric | Average | Peak | Allocated |
|--------|---------|------|-----------|
| CPU | 0.25% | ~14% | 4 vCPU |
| Memory | ~7.2% (~580 MB) | ~9% (~740 MB) | 8 GB |

The app server is a **control plane only** — API routing, session management, S3/DB reads. All compute-intensive work runs in sandbox containers.

### Changes

- **`lib/compute-stack.ts`**: Reduce app task CPU/memory, add auto scaling for both App and OpenResty services
- **`test/stacks.test.ts`**: Update assertions for new sizing, add auto scaling verification
- **`lib/AGENTS.md`**: Update documentation to reflect new architecture
- **`README.md`**: Update cost estimate table

### Auto Scaling Configuration

| Service | Min | Max | CPU Target | Memory Target |
|---------|-----|-----|------------|---------------|
| App | 1 | 3 | 60% | 70% |
| OpenResty | 1 | 3 | 60% | — |

Cooldowns: 60s scale-out, 300s scale-in (asymmetric to prevent flapping).

## Test plan

- [x] Build passes (`npm run build`)
- [x] Unit tests pass (`npm run test:ts`)
- [x] CI checks pass (both commits)
- [x] Reviewer bot findings addressed (no findings)
- [x] Deployed to staging
- [x] **E2E tests pass**
  - [x] TC-003: Login
  - [x] TC-004: Conversation List
  - [x] TC-005: New Conversation

## Checklist

- [x] Unit tests updated for new task sizing and auto scaling
- [x] Documentation updated (lib/AGENTS.md, README.md)
- [x] E2E test cases updated if needed (no changes needed)