### PR TITLE
fix(docker): add missing fork patches for skills/hooks API endpoints

### DIFF
--- a/docker/download-fork-patches.sh
+++ b/docker/download-fork-patches.sh
@@ -15,12 +15,15 @@ FORK_REPO="${FORK_REPO:-zxkane/openhands}"
 FORK_REF="${FORK_REF:-7a481ec3a7ec071851a3a854bd0c76b338c88e7b}"
 BASE_URL="https://raw.githubusercontent.com/${FORK_REPO}/${FORK_REF}"
 
-# 14 upstream Python files modified in the fork
+# 17 upstream Python files modified/added in the fork
 FILES="
 openhands/app_server/sandbox/remote_sandbox_service.py
 openhands/app_server/app_conversation/app_conversation_service.py
 openhands/app_server/app_conversation/live_status_app_conversation_service.py
 openhands/app_server/app_conversation/app_conversation_router.py
+openhands/app_server/app_conversation/app_conversation_models.py
+openhands/app_server/app_conversation/hook_loader.py
+openhands/app_server/app_conversation/skill_loader.py
 openhands/app_server/event_callback/webhook_router.py
 openhands/app_server/services/db_session_injector.py
 openhands/server/config/server_config.py

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1502,7 +1502,7 @@ security_analyzer = "llm"",
               "Timeout": 10,
             },
             "Image": {
-              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:deab8f475177f25208ab4b7741db6dbb9792a3e3dbf72f508d3f3847e25ea69e",
+              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:80b918e9900a42dd02ea9130c369470ee00ee8bf06e7a868e8293cf86ef81ab4",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",


### PR DESCRIPTION
## Summary
- Add 3 missing files to `download-fork-patches.sh`: `app_conversation_models.py`, `hook_loader.py`, `skill_loader.py`
- These files were modified/added in the fork but not downloaded, causing `ImportError: cannot import name 'GetHooksResponse'` at container startup
- Both staging and production deployments fail with this error

## Root Cause
Fork commit `7a481ec` added skills/hooks API endpoints to `app_conversation_router.py` which imports types from `app_conversation_models.py` and modules `hook_loader.py`/`skill_loader.py`. The download script was not updated to include these files.

## Test Plan
- [x] Build passes (`npm run build`)
- [x] Unit tests pass (`npm run test` — 129 passed, 1 snapshot updated)
- [ ] CI checks pass
- [ ] Deploy to staging — verify no ImportError
- [ ] Deploy to production