### PR TITLE
fix(docker): add missing settings.py fork patch

### DIFF
--- a/docker/download-fork-patches.sh
+++ b/docker/download-fork-patches.sh
@@ -15,7 +15,7 @@ FORK_REPO="${FORK_REPO:-zxkane/openhands}"
 FORK_REF="${FORK_REF:-7a481ec3a7ec071851a3a854bd0c76b338c88e7b}"
 BASE_URL="https://raw.githubusercontent.com/${FORK_REPO}/${FORK_REF}"
 
-# 17 upstream Python files modified/added in the fork
+# 18 upstream Python files modified/added in the fork
 FILES="
 openhands/app_server/sandbox/remote_sandbox_service.py
 openhands/app_server/app_conversation/app_conversation_service.py
@@ -28,6 +28,7 @@ openhands/app_server/event_callback/webhook_router.py
 openhands/app_server/services/db_session_injector.py
 openhands/server/config/server_config.py
 openhands/storage/data_models/secrets.py
+openhands/storage/data_models/settings.py
 openhands/app_server/config.py
 openhands/app_server/event_callback/sql_event_callback_service.py
 openhands/llm/bedrock.py

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1502,7 +1502,7 @@ security_analyzer = "llm"",
               "Timeout": 10,
             },
             "Image": {
-              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:80b918e9900a42dd02ea9130c369470ee00ee8bf06e7a868e8293cf86ef81ab4",
+              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:845c747897b7c8f7ea137a3ab054a8a2a75f9c820fb8761aebd4068b308406d4",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",


### PR DESCRIPTION
## Summary
- Add `openhands/storage/data_models/settings.py` to `download-fork-patches.sh`
- Fork's `app_conversation_models.py` imports `SandboxGroupingStrategy` from this file
- Without it: `ImportError: cannot import name 'SandboxGroupingStrategy'` at startup

Follow-up to #70 which added the first batch of missing files.

## Test Plan
- [x] Build passes
- [x] Unit tests pass (129 passed, 1 snapshot updated)
- [ ] CI checks pass
- [ ] Deploy to staging — verify no ImportError