### PR TITLE
fix(docker): revert extra fork patches that broke base image

### DIFF
--- a/docker/download-fork-patches.sh
+++ b/docker/download-fork-patches.sh
@@ -15,20 +15,19 @@ FORK_REPO="${FORK_REPO:-zxkane/openhands}"
 FORK_REF="${FORK_REF:-7a481ec3a7ec071851a3a854bd0c76b338c88e7b}"
 BASE_URL="https://raw.githubusercontent.com/${FORK_REPO}/${FORK_REF}"
 
-# 18 upstream Python files modified/added in the fork
+# 14 upstream Python files modified in the fork (verified via GitHub compare API:
+# gh api repos/zxkane/openhands/compare/<upstream-1.6.0-sha>...<fork-ref>)
+# Do NOT add files here that are not in the fork diff — the base image already has them.
+# Adding unmodified upstream files can break compatibility when the base image updates.
 FILES="
 openhands/app_server/sandbox/remote_sandbox_service.py
 openhands/app_server/app_conversation/app_conversation_service.py
 openhands/app_server/app_conversation/live_status_app_conversation_service.py
 openhands/app_server/app_conversation/app_conversation_router.py
-openhands/app_server/app_conversation/app_conversation_models.py
-openhands/app_server/app_conversation/hook_loader.py
-openhands/app_server/app_conversation/skill_loader.py
 openhands/app_server/event_callback/webhook_router.py
 openhands/app_server/services/db_session_injector.py
 openhands/server/config/server_config.py
 openhands/storage/data_models/secrets.py
-openhands/storage/data_models/settings.py
 openhands/app_server/config.py
 openhands/app_server/event_callback/sql_event_callback_service.py
 openhands/llm/bedrock.py

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1502,7 +1502,7 @@ security_analyzer = "llm"",
               "Timeout": 10,
             },
             "Image": {
-              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:845c747897b7c8f7ea137a3ab054a8a2a75f9c820fb8761aebd4068b308406d4",
+              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:989839cbf9b6734eb0cc775dc1536755c2703d4e80a9d72bdcd411e68e85d56a",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",


### PR DESCRIPTION
## Summary
- Revert PR #70 and #71's additions of non-fork files to `download-fork-patches.sh`
- Root cause was stale Docker build cache using old base image, not missing fork files
- The base image `openhands:1.6.0` already contains `GetHooksResponse`, `hook_loader.py`, etc.
- Downloading non-fork files overwrote base image files and introduced new ImportErrors

## Root Cause Analysis
The `openhands:1.6.0` Docker tag is a rolling tag. The CDK build used a cached old version
that predated the hooks/skills API. Fresh pulls of `1.6.0` include all needed files.
Adding non-fork files from the fork download list caused cascading import failures because
the fork's copies of those files may reference different internal APIs.

## Test Plan
- [x] Build passes
- [x] Unit tests pass (129 passed)
- [ ] CI checks pass
- [ ] Deploy to staging — verify app starts without ImportError