### PR TITLE
fix(docker): bump LAST_UPDATED to force base image re-pull

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@
 # Pin to specific version for stability
 # Check https://github.com/All-Hands-AI/OpenHands/releases for latest releases
 # LAST_UPDATED forces CDK to rebuild when bumped (picks up base image security patches)
-ARG LAST_UPDATED=2026-04-08
+ARG LAST_UPDATED=2026-04-12
 ARG OPENHANDS_VERSION=1.6.0
 FROM docker.openhands.dev/openhands/openhands:${OPENHANDS_VERSION}
 

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1502,7 +1502,7 @@ security_analyzer = "llm"",
               "Timeout": 10,
             },
             "Image": {
-              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:989839cbf9b6734eb0cc775dc1536755c2703d4e80a9d72bdcd411e68e85d56a",
+              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:68616b48486d2d690bfc37fc40b1d04851923e42537ccec98aef5ac408ee9938",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",


### PR DESCRIPTION
## Summary
- Bump `LAST_UPDATED` from 2026-04-08 to 2026-04-12
- Forces CDK to rebuild Docker image with fresh base image pull
- Root cause: `openhands:1.6.0` is a rolling tag; buildx cached stale layer missing `GetHooksResponse`

## Test Plan
- [x] Build + tests pass (129 passed)
- [ ] CI checks pass
- [ ] Deploy staging — no ImportError