### PR TITLE
fix(docker): pin base image to manifest digest to prevent stale cache

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,10 +15,13 @@
 
 # Pin to specific version for stability
 # Check https://github.com/All-Hands-AI/OpenHands/releases for latest releases
-# LAST_UPDATED forces CDK to rebuild when bumped (picks up base image security patches)
-ARG LAST_UPDATED=2026-04-12
+# OPENHANDS_IMAGE_DIGEST pins the exact base image content (multi-arch manifest digest).
+# This prevents Docker build cache from silently using a stale base image layer.
+# To update: docker manifest inspect docker.openhands.dev/openhands/openhands:<version>
+# and use the top-level digest (sha256:...) from the manifest list.
 ARG OPENHANDS_VERSION=1.6.0
-FROM docker.openhands.dev/openhands/openhands:${OPENHANDS_VERSION}
+ARG OPENHANDS_IMAGE_DIGEST=sha256:5c0dc26f467bf8e47a6e76308edb7a30af4084b17e23a3460b5467008b12111b
+FROM docker.openhands.dev/openhands/openhands:${OPENHANDS_VERSION}@${OPENHANDS_IMAGE_DIGEST}
 
 # Upgrade system packages to fix CVEs (openssl, gnutls28, etc.)
 RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*

--- a/lib/compute-stack.ts
+++ b/lib/compute-stack.ts
@@ -33,6 +33,9 @@ import {
  * Latest release: https://github.com/OpenHands/OpenHands/releases
  */
 const DEFAULT_OPENHANDS_VERSION = '1.6.0';
+// Pin base image to exact manifest digest to prevent Docker build cache from using stale layers.
+// Update: docker manifest inspect docker.openhands.dev/openhands/openhands:<version> | jq '.digest'
+const DEFAULT_OPENHANDS_IMAGE_DIGEST = 'sha256:5c0dc26f467bf8e47a6e76308edb7a30af4084b17e23a3460b5467008b12111b';
 const DEFAULT_RUNTIME_VERSION = '1.6-nikolaik';
 
 /**
@@ -318,6 +321,7 @@ export class ComputeStack extends cdk.Stack {
       platform: Platform.LINUX_ARM64,
       buildArgs: {
         OPENHANDS_VERSION: DEFAULT_OPENHANDS_VERSION,
+        OPENHANDS_IMAGE_DIGEST: DEFAULT_OPENHANDS_IMAGE_DIGEST,
       },
       exclude: [
         'agent-server',

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1502,7 +1502,7 @@ security_analyzer = "llm"",
               "Timeout": 10,
             },
             "Image": {
-              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:68616b48486d2d690bfc37fc40b1d04851923e42537ccec98aef5ac408ee9938",
+              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:c8676821be84a08eb42d9bb390be345d46f96f092f6f209613372669d3ad69d6",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",


### PR DESCRIPTION
## Summary
- Pin `FROM openhands:1.6.0` to exact manifest digest via `@sha256:...` syntax
- Pass digest as CDK `buildArgs` so changing it triggers a rebuild
- Removes `LAST_UPDATED` hack — digest pinning is the proper solution

## Root Cause
Docker build cache held a stale `openhands:1.6.0` ARM64 layer (SDK 1.11.4)
that was missing `GetHooksResponse` and other hooks/skills API types added
in a later image push under the same rolling tag. `docker build` without
`--pull` reused the cached layer. CDK `DockerImageAsset` doesn't support
`--pull`, so pinning to digest is the CDK-native fix.

## Test Plan
- [x] Build passes
- [x] Tests pass (129 passed)
- [ ] CI checks pass
- [ ] Deploy staging — no ImportError, SDK 1.15.0