### PR TITLE
fix(orchestrator): apply Alpine package upgrades to patch CVEs

### DIFF
--- a/services/sandbox-orchestrator/Dockerfile
+++ b/services/sandbox-orchestrator/Dockerfile
@@ -1,5 +1,7 @@
 FROM public.ecr.aws/docker/library/node:24-alpine AS builder
 
+RUN apk -U upgrade --no-cache
+
 WORKDIR /app
 
 COPY package.json package-lock.json* ./
@@ -11,6 +13,8 @@ RUN npx tsc
 
 # Production stage
 FROM public.ecr.aws/docker/library/node:24-alpine
+
+RUN apk -U upgrade --no-cache
 
 WORKDIR /app
 

--- a/services/sandbox-orchestrator/Dockerfile
+++ b/services/sandbox-orchestrator/Dockerfile
@@ -1,6 +1,6 @@
 FROM public.ecr.aws/docker/library/node:24-alpine AS builder
 
-RUN apk -U upgrade --no-cache
+RUN apk update && apk upgrade --no-cache && rm -rf /var/cache/apk/*
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ RUN npx tsc
 # Production stage
 FROM public.ecr.aws/docker/library/node:24-alpine
 
-RUN apk -U upgrade --no-cache
+RUN apk update && apk upgrade --no-cache && rm -rf /var/cache/apk/*
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Add `apk -U upgrade --no-cache` to both stages of `services/sandbox-orchestrator/Dockerfile`
- Patches 11 CVEs flagged on the running orchestrator task: 7× openssl (CVE-2026-31789, CVE-2026-2673, CVE-2026-28387/8/9/90, CVE-2026-31790), 2× zlib (CVE-2026-22184, CVE-2026-27171), 2× musl (CVE-2026-40200, CVE-2026-6042)
- Verified locally that the rebuilt image ships openssl/libssl3/libcrypto3 3.5.6-r0, zlib 1.3.2-r0, musl 1.2.5-r23 — all at or above advisory-required versions

## Design
- [x] No design canvas needed — single-line Dockerfile patch with no behavioral change

## Test Plan
- [x] Local build succeeds (`docker buildx build --platform linux/amd64`)
- [x] Verified upgraded package versions in built image (`apk info -v`)
- [x] `npm run build` passes
- [x] `npm run test:ts` passes (existing UserConfigStack failures are pre-existing Docker-bundle issues on main, unrelated)
- [ ] CI checks pass
- [ ] Reviewer bot findings addressed (no new findings)
- [ ] Staging deploy verifies orchestrator task picks up patched image

## Checklist
- [x] No new unit tests needed — change is base-image hardening, no behavior change
- [ ] Follow-up: track upstream `node:24-alpine` digest pin (#74) so periodic rebuilds also pull patches