### PR TITLE
fix(openresty): bump LAST_UPDATED to pull latest CVE patches

### DIFF
--- a/docker/openresty/Dockerfile
+++ b/docker/openresty/Dockerfile
@@ -2,7 +2,7 @@
 # Routes /runtime/{conversation_id}/{port}/... to sandbox Fargate task IP:port
 # Discovers sandbox IPs via the Sandbox Orchestrator API (Cloud Map DNS)
 # LAST_UPDATED forces CDK to rebuild when bumped (picks up base image security patches)
-ARG LAST_UPDATED=2026-04-08
+ARG LAST_UPDATED=2026-05-13
 FROM openresty/openresty:1.29.2.3-alpine-fat
 
 # Upgrade Alpine packages to pick up latest security patches

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1502,7 +1502,7 @@ security_analyzer = "llm"",
               "Timeout": 10,
             },
             "Image": {
-              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:c8676821be84a08eb42d9bb390be345d46f96f092f6f209613372669d3ad69d6",
+              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:f0f2b4cd19d66b006010f0bf4b91e55044057d4a09e1676e5f0cc6b0e25313fc",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -1867,7 +1867,7 @@ security_analyzer = "llm"",
               "Timeout": 5,
             },
             "Image": {
-              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:43bbc2171ffe21b8f9e54b816ef24868d6d7bf58985b0c9fb76ae48609050ac6",
+              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:a9efe78e4429e3a15e416b2203226fb0c87c4bf16e3b2435817ee24e84f64493",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",


### PR DESCRIPTION
## Summary
- Bump `ARG LAST_UPDATED` from `2026-04-08` to `2026-05-13` in `docker/openresty/Dockerfile` to invalidate the CDK asset hash and force a rebuild
- Dockerfile already runs `apk update && apk upgrade --no-cache` (line 9), but without an asset hash change CDK reuses the cached image and the upgrade layer never re-executes
- Patches 14 CVEs on the running openresty task: 7× openssl, 2× zlib, 2× musl, 1× nghttp2, 1× xz, 1× libpng

## Design
- [x] No design canvas needed — single-line bump using the existing `LAST_UPDATED` mechanism (same pattern as #73)

## Test Plan
- [x] Local build succeeds (`docker buildx build --platform linux/amd64`)
- [x] Verified upgraded package versions in built image: `openssl/libssl3/libcrypto3 3.5.6-r0`, `zlib 1.3.2-r0`, `musl 1.2.5-r23`, `nghttp2-libs 1.69.0-r0`, `xz-libs 5.8.3-r0`, `libpng 1.6.57-r0` — all at or above advisory-required versions
- [x] `npm run build` passes
- [ ] CI checks pass
- [ ] Reviewer bot findings addressed
- [ ] Staging deploy verifies openresty container picks up patched image

## Checklist
- [x] No new unit tests needed — Dockerfile bump, no behavior change
- [ ] Follow-up: consider auto-bumping `LAST_UPDATED` on a schedule (cron workflow) so periodic rebuilds also pull patches without manual PRs