### PR TITLE
chore(skills): refresh autonomous-dev-team skills to latest

### DIFF
--- a/skills-lock.json
+++ b/skills-lock.json
@@ -4,27 +4,32 @@
     "autonomous-common": {
       "source": "zxkane/autonomous-dev-team",
       "sourceType": "github",
-      "computedHash": "1e58f32a2888aed5ffc838eb8ee84414ef7cd1d915766a43f688dc2c8a4fc8e4"
+      "skillPath": "skills/autonomous-common/SKILL.md",
+      "computedHash": "e0df9093b957cddeca36bde0f0011e379a2a265b26f47cfc6aa015e1a7ce6828"
     },
     "autonomous-dev": {
       "source": "zxkane/autonomous-dev-team",
       "sourceType": "github",
-      "computedHash": "f084d35c385c58b5eb94a4d26f30a796bf7ead0e25a8c0cfc741218ade5abf5c"
+      "skillPath": "skills/autonomous-dev/SKILL.md",
+      "computedHash": "7e18a05bbca7421e536ed38ea7be9ed9071f95a2aab53951ee683325ee258003"
     },
     "autonomous-dispatcher": {
       "source": "zxkane/autonomous-dev-team",
       "sourceType": "github",
-      "computedHash": "2f234dfe815a19151f7cb5c3b125a4059c9e730108dc368f0abe8842d5cf3931"
+      "skillPath": "skills/autonomous-dispatcher/SKILL.md",
+      "computedHash": "d0b0ef964897479ce894bbc4022ac0bf3270da6a3b22d378379ce3fb13204368"
     },
     "autonomous-review": {
       "source": "zxkane/autonomous-dev-team",
       "sourceType": "github",
-      "computedHash": "74db4d8b8693eb3e1ffd13942d8f420755282a2e6a0c5b401ca1cb18328e3a6c"
+      "skillPath": "skills/autonomous-review/SKILL.md",
+      "computedHash": "d5f3f29a4d98cab1b97854dbc5c50cc6730cc364f9a003ac12a6e2c888172254"
     },
     "create-issue": {
       "source": "zxkane/autonomous-dev-team",
       "sourceType": "github",
-      "computedHash": "6e85141dcf2fbd76a48737a66ffa2ff6d4eab876c24db2bf3dc588acf11b4419"
+      "skillPath": "skills/create-issue/SKILL.md",
+      "computedHash": "391535323e24131c3b6fcd7fa2df04fa8cba9e0e04b18b92f9eb6da3c3f8dd63"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Re-installed all 5 autonomous-dev-team skills (autonomous-common, autonomous-dev, autonomous-dispatcher, autonomous-review, create-issue) via \`npx skills add zxkane/autonomous-dev-team -s '*' -a claude-code\`
- Picks up upstream skill content updates and adds the new \`skillPath\` field that the \`skills\` CLI now requires for future in-place updates (\`npx skills update\` was unable to refresh the old lock format)
- Skill content lives under gitignored \`.claude/skills/<name>/\`; only \`skills-lock.json\` is tracked

## Design
- [x] No design canvas needed — pure dependency refresh

## Test Plan
- [x] \`npx skills add\` ran cleanly, all 5 skills marked "(copied)"
- [x] No accidental placeholder dirs created (used \`-a claude-code\` selectively)
- [ ] CI checks pass

## Checklist
- [x] No new unit tests needed — skills are dev-time tooling, not runtime code
- [ ] Follow-up: hooks symlink \`hooks -> .claude/skills/autonomous-common/hooks\` is dev-machine local setup (not committed); each clone runs the documented \`ln -sf\` step