### PR TITLE
chore(ci): bump GitHub Actions to Node 24 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -32,7 +32,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
@@ -46,7 +46,7 @@ jobs:
           fi
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -29,7 +29,7 @@ jobs:
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Full history for git-secrets
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -102,7 +102,7 @@ jobs:
 
       - name: Upload security reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: security-reports
           path: |
@@ -113,7 +113,7 @@ jobs:
 
       - name: Comment PR with security summary
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           # Use environment variables for any dynamic data
           NPM_HIGH: ${{ steps.npm-audit.outputs.high_vulns }}
@@ -200,7 +200,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run npm audit
         run: |
@@ -216,10 +216,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -259,7 +259,7 @@ jobs:
 
       - name: Upload summary
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: security-summary
           path: security-summary.md


### PR DESCRIPTION
## Summary
Resolves "Node.js 20 actions are deprecated" warnings reported on \`dependency-check\`, \`security-checks\`, and \`infrastructure-scan\` jobs. GitHub will force Node.js 24 on June 2nd, 2026 and remove Node 20 from runners on September 16th, 2026.

| Action | Before | After |
|--------|--------|-------|
| actions/checkout | v4 | **v6** |
| actions/setup-node | v4 | **v6** |
| actions/setup-python | v5 | **v6** |
| actions/github-script | v7 | **v9** |
| actions/upload-artifact | v4 | **v7** |

All usages stick to standard options (\`fetch-depth\`, \`ref\`, \`token\`, \`name\`, \`path\`, \`retention-days\`) that remain supported in the new majors. No deprecated v4-era artifact merging or v3 token plumbing in use.

## Design
- [x] No design canvas — workflow chore

## Test Plan
- [x] All workflow files updated consistently
- [ ] CI runs without Node 20 deprecation warnings
- [ ] All existing checks still pass (build-and-test, security-checks, dependency-check, infrastructure-scan, Amazon Q Developer)

## Checklist
- [x] No code change in \`bin/\`, \`lib/\`, \`docker/\`, etc.
- [ ] After merge, watch the next PR's CI to confirm warnings cleared