### PR TITLE
feat(upgrade): upgrade OpenHands from v1.6.0 to v1.7.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,31 +37,34 @@ RUN pip install --no-cache-dir boto3 openhands-tools==1.19.1
 # The fork (zxkane/openhands) has clean per-feature commits against the release tag.
 # See docker/CLAUDE.md for the full list of patched files and fork branch strategy.
 # Pin to commit SHA for reproducible builds (branch: custom/v1.7.0-fargate).
-# Fargate branch: RemoteSandboxService compatible, multi-tenant isolation, Bedrock enhancements.
-# TODO(PR #81): bump to the final SHA once the v1.7.0 fork branch is complete
-# (current value is the partial cherry-pick checkpoint, 17/20 commits ported).
-ARG FORK_REF=b707ea5cc1a410e9dd26058071a260188da99fc9
+# Fargate branch: RemoteSandboxService compatible, multi-tenant isolation, V1 Cognito wiring.
+ARG FORK_REF=4e480e79c47fb4c66c94c8176d130abdd6d5d2e9
 COPY download-fork-patches.sh /opt/download-fork-patches.sh
 RUN FORK_REF=${FORK_REF} sh /opt/download-fork-patches.sh
 
 # ─── Custom modules (NEW files, not upstream modifications) ──────────────────
+#
+# v1.7.0: COPY destinations migrated to V1 paths (openhands.app_server.*).
+# Upstream deleted openhands/server/user_auth/ and openhands/storage/{settings,
+# secrets,conversation}/ in v1.7.0. The custom modules now extend the V1 ABCs
+# (UserAuth / SettingsStore / SecretsStore) and live alongside the upstream
+# defaults under openhands/app_server/{user_auth,settings,secrets}/.
+# cognito_file_conversation_store.py is dropped — there is no V1 equivalent;
+# multi-tenant conversation isolation runs through CognitoSQLAppConversationInfoService.
 
 # Patched auth_user_context.py for webhook authentication from Docker internal network
 COPY patched/ /app/patched/
 
-# Cognito user authentication (Lambda@Edge header-based identity)
-COPY cognito_user_auth.py /app/openhands/server/user_auth/
-
-# User-scoped conversation storage (S3 path: users/{user_id}/conversations/{sid}/)
-COPY cognito_file_conversation_store.py /app/openhands/storage/conversation/
+# Cognito user authentication (Lambda@Edge header-based identity) — V1 path
+COPY cognito_user_auth.py /app/openhands/app_server/user_auth/
 
 # User config loader for MCP configurations from S3
 COPY user_config_loader.py /app/openhands/server/user_config_loader.py
 
 # User-scoped settings and secrets stores for multi-tenancy (CRITICAL SECURITY)
 # Store data at users/{user_id}/settings.json and users/{user_id}/secrets.json
-COPY s3_settings_store.py /app/openhands/storage/settings/
-COPY s3_secrets_store.py /app/openhands/storage/secrets/
+COPY s3_settings_store.py /app/openhands/app_server/settings/
+COPY s3_secrets_store.py /app/openhands/app_server/secrets/
 
 # Multi-tenant conversation isolation (user_id-based filtering)
 COPY cognito_sql_conversation_info_service.py /app/openhands/app_server/app_conversation/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,7 +38,7 @@ RUN pip install --no-cache-dir boto3 openhands-tools==1.19.1
 # See docker/CLAUDE.md for the full list of patched files and fork branch strategy.
 # Pin to commit SHA for reproducible builds (branch: custom/v1.7.0-fargate).
 # Fargate branch: RemoteSandboxService compatible, multi-tenant isolation, V1 Cognito wiring.
-ARG FORK_REF=4e480e79c47fb4c66c94c8176d130abdd6d5d2e9
+ARG FORK_REF=bb3fe51c920eec0b51bc7e118e340b582db0649f
 COPY download-fork-patches.sh /opt/download-fork-patches.sh
 RUN FORK_REF=${FORK_REF} sh /opt/download-fork-patches.sh
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,9 @@
 # This prevents Docker build cache from silently using a stale base image layer.
 # To update: docker manifest inspect docker.openhands.dev/openhands/openhands:<version>
 # and use the top-level digest (sha256:...) from the manifest list.
-ARG OPENHANDS_VERSION=1.6.0
+ARG OPENHANDS_VERSION=1.7.0
+# TODO(PR #81): replace with the actual sha256 of openhands/openhands:1.7.0 once
+# the image is pulled in CI / staging — see lib/compute-stack.ts for the same TODO.
 ARG OPENHANDS_IMAGE_DIGEST=sha256:5c0dc26f467bf8e47a6e76308edb7a30af4084b17e23a3460b5467008b12111b
 FROM docker.openhands.dev/openhands/openhands:${OPENHANDS_VERSION}@${OPENHANDS_IMAGE_DIGEST}
 
@@ -27,16 +29,18 @@ FROM docker.openhands.dev/openhands/openhands:${OPENHANDS_VERSION}@${OPENHANDS_I
 RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 
 # Install boto3 for AWS Bedrock support (required by litellm for AWS authentication)
-# Upgrade openhands-tools to match agent-server-custom SDK (v1.15.0)
-RUN pip install --no-cache-dir boto3 openhands-tools==1.15.0
+# Upgrade openhands-tools to match agent-server-custom SDK (v1.19.1)
+RUN pip install --no-cache-dir boto3 openhands-tools==1.19.1
 
 # ─── Build-time: Download patched upstream files from fork ───────────────────
 # Replaces the old apply-patch.sh (2000+ line regex patching at startup).
 # The fork (zxkane/openhands) has clean per-feature commits against the release tag.
 # See docker/CLAUDE.md for the full list of patched files and fork branch strategy.
-# Pin to commit SHA for reproducible builds (tag: custom-v1.6.0-fargate-r1)
-# Fargate branch: RemoteSandboxService compatible, multi-tenant isolation, Bedrock enhancements
-ARG FORK_REF=7a481ec3a7ec071851a3a854bd0c76b338c88e7b
+# Pin to commit SHA for reproducible builds (branch: custom/v1.7.0-fargate).
+# Fargate branch: RemoteSandboxService compatible, multi-tenant isolation, Bedrock enhancements.
+# TODO(PR #81): bump to the final SHA once the v1.7.0 fork branch is complete
+# (current value is the partial cherry-pick checkpoint, 17/20 commits ported).
+ARG FORK_REF=b707ea5cc1a410e9dd26058071a260188da99fc9
 COPY download-fork-patches.sh /opt/download-fork-patches.sh
 RUN FORK_REF=${FORK_REF} sh /opt/download-fork-patches.sh
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,9 +20,9 @@
 # To update: docker manifest inspect docker.openhands.dev/openhands/openhands:<version>
 # and use the top-level digest (sha256:...) from the manifest list.
 ARG OPENHANDS_VERSION=1.7.0
-# TODO(PR #81): replace with the actual sha256 of openhands/openhands:1.7.0 once
-# the image is pulled in CI / staging — see lib/compute-stack.ts for the same TODO.
-ARG OPENHANDS_IMAGE_DIGEST=sha256:5c0dc26f467bf8e47a6e76308edb7a30af4084b17e23a3460b5467008b12111b
+# Multi-arch manifest list digest (linux/amd64 + linux/arm64) for openhands/openhands:1.7.0.
+# Refresh: docker buildx imagetools inspect docker.openhands.dev/openhands/openhands:<version>
+ARG OPENHANDS_IMAGE_DIGEST=sha256:916abcb15cc451d96853bd41c55117bb2ff3de0b9914cdcd861d338055798dc6
 FROM docker.openhands.dev/openhands/openhands:${OPENHANDS_VERSION}@${OPENHANDS_IMAGE_DIGEST}
 
 # Upgrade system packages to fix CVEs (openssl, gnutls28, etc.)

--- a/docker/agent-server-custom/Dockerfile
+++ b/docker/agent-server-custom/Dockerfile
@@ -1,13 +1,14 @@
 # Custom agent-server build with boto3 included in PyInstaller bundle
 # This builds the agent-server binary from source with boto3/botocore as hidden imports
 #
-# Build-time patches (Patch 23-26) are applied via apply-sdk-patches.py
-# These patches MUST be at build time because PyInstaller creates an immutable binary.
-# Runtime patches are in docker/apply-patch.sh for the OpenHands container.
+# Build-time patches are applied via apply-sdk-patches.py — see that file for the
+# active patch set. These patches MUST be at build time because PyInstaller
+# creates an immutable binary. Runtime patches are in docker/apply-startup.sh
+# for the OpenHands container.
 
 # Stage 1: Build the binary
 # LAST_UPDATED forces CDK to rebuild when bumped (picks up base image security patches)
-ARG LAST_UPDATED=2026-04-08
+ARG LAST_UPDATED=2026-05-14
 FROM python:3.12-slim-bookworm AS builder
 
 # Install build dependencies
@@ -20,13 +21,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install uv for fast package management
 RUN pip install uv
 
-# Clone the OpenHands SDK repository
+# Clone the OpenHands SDK repository.
+# Pinned to v1.19.1 alongside the OpenHands v1.7.0 upgrade (PR #81). The fork
+# patches in apply-sdk-patches.py are anchored against this exact version.
 WORKDIR /build
-RUN git clone --depth 1 --branch v1.15.0 https://github.com/OpenHands/software-agent-sdk.git .
+ARG SDK_VERSION=v1.19.1
+RUN git clone --depth 1 --branch ${SDK_VERSION} https://github.com/OpenHands/software-agent-sdk.git .
 
 # Copy and run SDK patches
-# Patches 23, 25-27: Handle invalid/masked secrets + Bedrock max_output_tokens
-# See apply-sdk-patches.py for detailed documentation
+# Patches 23, 25-26, 28-32: secret-resume validators + Bedrock listing/region/env
+# See apply-sdk-patches.py for detailed documentation.
 COPY apply-sdk-patches.py /build/
 RUN python3 /build/apply-sdk-patches.py /build
 
@@ -194,8 +198,8 @@ RUN id -u openhands 2>/dev/null || useradd -m -s /bin/bash openhands
 # Copy the built binary
 COPY --from=builder /build/dist/openhands-agent-server /usr/local/bin/openhands-agent-server
 
-# Copy VSCode server from official agent-server image
-COPY --from=ghcr.io/openhands/agent-server:1.15.0-python /openhands/.openvscode-server /openhands/.openvscode-server
+# Copy VSCode server from official agent-server image (must track SDK_VERSION above)
+COPY --from=ghcr.io/openhands/agent-server:1.19.1-python /openhands/.openvscode-server /openhands/.openvscode-server
 
 # Set permissions
 RUN chown -R openhands:openhands /openhands && \

--- a/docker/agent-server-custom/apply-sdk-patches.py
+++ b/docker/agent-server-custom/apply-sdk-patches.py
@@ -6,14 +6,26 @@ This script applies patches to the OpenHands SDK source code before PyInstaller
 bundles it into a binary. These patches MUST be applied at build time because
 the final binary is immutable.
 
-Patches:
+Patches (active):
   - Patch 23: Skip invalid/masked secrets during conversation resume (AgentContext)
   - Patch 25: Filter invalid secrets from JSON before model_validate_json
   - Patch 26: Filter invalid secret_sources from ConversationState
-  - Patch 27: Fix Bedrock max_output_tokens when litellm reports context window as output limit
+  - Patch 28: Default credential chain for _list_bedrock_foundation_models
+              (allows IAM-role / IRSA / AWS_PROFILE Bedrock listing without explicit creds)
+  - Patch 29: Cross-region inference profile listing
+              (adds bedrock/us. / bedrock/eu. / bedrock/apac. / bedrock/global. model IDs)
+  - Patch 30: Cross-region prefix stripping in get_litellm_model_info
+              (lets bedrock/us.anthropic.claude-* find its model_cost entry)
+  - Patch 31: AWS_DEFAULT_REGION setdefault in _set_env_side_effects
+              (boto3 prefers AWS_DEFAULT_REGION over AWS_REGION_NAME for some auth modes)
+  - Patch 32: Env-hint trigger for Bedrock listing in get_supported_llm_models
+              (AWS_PROFILE / AWS_ROLE_ARN / AWS_WEB_IDENTITY_TOKEN_FILE → list Bedrock too)
 
-Removed:
-  - Patch 24: (SDK v1.15.0 already uses model_dump(mode="json"), no longer needed)
+Removed (absorbed in upstream / obsolete):
+  - Patch 24: SDK uses model_dump(mode="json") since v1.15.0
+  - Patch 27: SDK v1.19.1 caps max_output_tokens to half the context window when
+              max_output_tokens >= context_window (llm.py:1273-1287). Same outcome
+              as the fork patch with a different mechanism.
 
 Usage:
   python3 apply-sdk-patches.py /path/to/build/directory
@@ -110,24 +122,21 @@ def patch_23_agent_context(build_dir: Path) -> bool:
 
 '''
 
-    # Find where to insert - after the secrets Field definition, before @field_validator
-    insert_pattern = r'(\s+secrets:.*?\)\n)(\n\s+@field_validator)'
-    insert_match = re.search(insert_pattern, content, re.DOTALL)
+    # Insert immediately before the first @field_validator inside AgentContext.
+    # In SDK v1.19.1 the order is: secrets → current_datetime → @field_validator("skills"),
+    # so anchoring on @field_validator (rather than on the secrets Field's closing paren)
+    # is the stable choice.
+    insert_pattern = r'(\n    @field_validator\("skills"\))'
+    insert_match = re.search(insert_pattern, content)
     if insert_match:
-        insert_pos = insert_match.end(1)
+        insert_pos = insert_match.start()
         content = content[:insert_pos] + patch_code + content[insert_pos:]
-        print("Patch 23: Added secret filter validator to AgentContext")
+        print("Patch 23: Added secret filter validator before @field_validator(\"skills\")")
     else:
-        # Try inserting after the last Field definition
-        insert_pattern2 = r'(load_public_skills:.*?skills repository\..*?"\n\s+\)\n)'
-        insert_match2 = re.search(insert_pattern2, content, re.DOTALL)
-        if insert_match2:
-            insert_pos = insert_match2.end(1)
-            content = content[:insert_pos] + patch_code + content[insert_pos:]
-            print("Patch 23: Added secret filter validator (alternative position)")
-        else:
-            print("ERROR: Could not find insertion point for Patch 23")
-            return False
+        print("ERROR: Could not find insertion point for Patch 23 "
+              "(no @field_validator(\"skills\") in AgentContext — "
+              "SDK structure may have changed again)")
+        return False
 
     agent_context_file.write_text(content)
     print("Patch 23: Successfully patched agent_context.py")
@@ -329,104 +338,270 @@ def patch_26_conversation_state(build_dir: Path) -> bool:
     return True
 
 
-def patch_27_bedrock_max_output_tokens(build_dir: Path) -> bool:
+def patch_28_29_32_bedrock_listing(build_dir: Path) -> bool:
     """
-    Patch 27: Fix Bedrock models where litellm reports max_output_tokens equal
-    to context window size (e.g. Kimi K2.5: max_output_tokens=262144).
+    Replaces SDK ``_list_bedrock_foundation_models`` and ``get_supported_llm_models``
+    in ``unverified_models.py`` with fork variants that:
 
-    When max_output_tokens == max_input_tokens, litellm is reporting the context
-    window size, not the actual output limit. Sending this as max_tokens causes
-    Bedrock to reject when input_tokens + max_tokens > context_window.
+    * Patch 28: drop the requirement that all three creds (region / access_key /
+      secret_key) be present. Pass them only when truthy so boto3 falls through to
+      the default credential chain (IAM role, IRSA, AWS_PROFILE, EC2 metadata).
+    * Patch 29: enumerate cross-region inference profiles via
+      ``list_inference_profiles(typeEquals="SYSTEM_DEFINED")`` and merge the
+      ``bedrock/us.``, ``bedrock/eu.``, ``bedrock/apac.``, ``bedrock/global.``
+      model IDs into the returned list.
+    * Patch 32: trigger ``_list_bedrock_foundation_models`` when
+      ``AWS_PROFILE`` / ``AWS_ROLE_ARN`` / ``AWS_WEB_IDENTITY_TOKEN_FILE`` is set
+      (env-hint mode), even without explicit static creds. Required for IRSA
+      and Cognito-federated EC2 IAM workflows where there are no AWS_* keys.
 
-    This patch:
-    a) Adds detection in llm.py to reset max_output_tokens to None
-    b) Adds a pop in chat_options.py to omit max_completion_tokens=None for Bedrock
+    These three patches are wired together (sharing a rewritten
+    ``_list_bedrock_foundation_models`` signature), so they ship as one atomic
+    rewrite of the file. We rewrite by replacing function bodies via regex
+    rather than full-file replacement so that re-anchoring on future SDK bumps
+    stays mechanical.
     """
-    # Part A: Patch llm.py — detect context-window-as-output-limit
-    llm_file = build_dir / "openhands-sdk/openhands/sdk/llm/llm.py"
-
-    if not llm_file.exists():
-        print(f"ERROR: Patch 27a - File not found: {llm_file}")
+    target = build_dir / "openhands-sdk/openhands/sdk/llm/utils/unverified_models.py"
+    if not target.exists():
+        print(f"ERROR: Patch 28/29/32 - File not found: {target}")
         return False
 
-    content = llm_file.read_text()
+    content = target.read_text()
 
-    # Insert after the max_output_tokens assignment block (after the o3 clamping)
-    # Target: after the "if 'o3' in self.model:" block, before _validate_context_window_size
-    # or the next method definition
-    anchor = '                    "Clamping max_output_tokens to %s for %s",'
+    # Replace the entire _list_bedrock_foundation_models function body.
+    list_pattern = re.compile(
+        r"def _list_bedrock_foundation_models\([^)]*\) -> list\[str\]:\n"
+        r"(?:.*\n)+?(?=\n\ndef get_supported_llm_models)",
+        re.MULTILINE,
+    )
+    list_replacement = (
+        'def _list_bedrock_foundation_models(\n'
+        '    aws_region_name: str | None = None,\n'
+        '    aws_access_key_id: str | None = None,\n'
+        '    aws_secret_access_key: str | None = None,\n'
+        ') -> list[str]:\n'
+        '    """List Bedrock foundation models + cross-region inference profiles.\n'
+        '\n'
+        '    Patch 28 (openhands-infra): all three creds are now optional. boto3\n'
+        '    falls through to the default credential chain when they are omitted,\n'
+        '    which lets IAM-role / IRSA / AWS_PROFILE workflows list Bedrock\n'
+        '    models without explicit access keys.\n'
+        '\n'
+        '    Patch 29 (openhands-infra): also enumerate SYSTEM_DEFINED inference\n'
+        '    profiles (cross-region routing) and surface them as bedrock/<prefix>\n'
+        '    model IDs alongside the foundation models.\n'
+        '    """\n'
+        '    boto3 = _get_boto3()\n'
+        '    if boto3 is None:\n'
+        '        logger.warning(\n'
+        '            "boto3 is not installed. To use Bedrock models,"\n'
+        '            "install with: openhands-sdk[boto3]"\n'
+        '        )\n'
+        '        return []\n'
+        '\n'
+        '    client_kwargs: dict[str, str] = {"service_name": "bedrock"}\n'
+        '    if aws_region_name:\n'
+        '        client_kwargs["region_name"] = aws_region_name\n'
+        '    if aws_access_key_id:\n'
+        '        client_kwargs["aws_access_key_id"] = aws_access_key_id\n'
+        '    if aws_secret_access_key:\n'
+        '        client_kwargs["aws_secret_access_key"] = aws_secret_access_key\n'
+        '\n'
+        '    try:\n'
+        '        client = boto3.client(**client_kwargs)\n'
+        '        foundation_models_list = client.list_foundation_models(\n'
+        '            byOutputModality="TEXT", byInferenceType="ON_DEMAND"\n'
+        '        )\n'
+        '        model_summaries = foundation_models_list["modelSummaries"]\n'
+        '        result = ["bedrock/" + model["modelId"] for model in model_summaries]\n'
+        '\n'
+        '        try:\n'
+        '            paginator = client.get_paginator("list_inference_profiles")\n'
+        '            for page in paginator.paginate(typeEquals="SYSTEM_DEFINED"):\n'
+        '                for profile in page.get("inferenceProfileSummaries", []):\n'
+        '                    profile_id = profile.get("inferenceProfileId")\n'
+        '                    if profile_id:\n'
+        '                        result.append("bedrock/" + profile_id)\n'
+        '        except Exception as profile_err:\n'
+        '            logger.debug(\n'
+        '                "Patch 29: list_inference_profiles failed (%s); "\n'
+        '                "skipping cross-region IDs.",\n'
+        '                profile_err,\n'
+        '            )\n'
+        '\n'
+        '        return result\n'
+        '    except Exception as err:\n'
+        '        logger.warning(\n'
+        '            "%s. Configure AWS_REGION_NAME and either AWS_ACCESS_KEY_ID/"\n'
+        '            "AWS_SECRET_ACCESS_KEY or an IAM-role / AWS_PROFILE if you "\n'
+        '            "want to use Bedrock models.",\n'
+        '            err,\n'
+        '        )\n'
+        '        return []\n'
+    )
+    if not list_pattern.search(content):
+        print("ERROR: Patch 28/29 - Could not locate _list_bedrock_foundation_models")
+        return False
+    content = list_pattern.sub(list_replacement, content, count=1)
+    print("Patch 28/29: Rewrote _list_bedrock_foundation_models (default cred chain + inference profiles)")
+
+    # Replace the gating block inside get_supported_llm_models (Patch 32).
+    gate_pattern = re.compile(
+        r"    bedrock_model_list = \[\]\n"
+        r"    if aws_region_name and aws_access_key_id and aws_secret_access_key:\n"
+        r"        bedrock_model_list = _list_bedrock_foundation_models\(\n"
+        r"            aws_region_name,\n"
+        r"            aws_access_key_id\.get_secret_value\(\),\n"
+        r"            aws_secret_access_key\.get_secret_value\(\),\n"
+        r"        \)\n"
+    )
+    gate_replacement = (
+        '    bedrock_model_list = []\n'
+        '    # Patch 32 (openhands-infra): trigger Bedrock listing when explicit creds\n'
+        '    # are present OR when env hints (AWS_PROFILE / AWS_ROLE_ARN /\n'
+        '    # AWS_WEB_IDENTITY_TOKEN_FILE) suggest the default credential chain can\n'
+        '    # resolve a session — paired with Patch 28 default-cred-chain support.\n'
+        '    _has_static_creds = bool(\n'
+        '        aws_region_name and aws_access_key_id and aws_secret_access_key\n'
+        '    )\n'
+        '    _has_env_hint = bool(\n'
+        '        os.environ.get("AWS_PROFILE")\n'
+        '        or os.environ.get("AWS_ROLE_ARN")\n'
+        '        or os.environ.get("AWS_WEB_IDENTITY_TOKEN_FILE")\n'
+        '    )\n'
+        '    if _has_static_creds or _has_env_hint:\n'
+        '        bedrock_model_list = _list_bedrock_foundation_models(\n'
+        '            aws_region_name,\n'
+        '            aws_access_key_id.get_secret_value() if aws_access_key_id else None,\n'
+        '            aws_secret_access_key.get_secret_value() if aws_secret_access_key else None,\n'
+        '        )\n'
+    )
+    if not gate_pattern.search(content):
+        print("ERROR: Patch 32 - Could not locate Bedrock gating block in get_supported_llm_models")
+        return False
+    content = gate_pattern.sub(gate_replacement, content, count=1)
+    print("Patch 32: Added env-hint trigger for Bedrock listing")
+
+    # Add `import os` if not already present (used by Patch 32 env-hint check).
+    if not re.search(r"^import os\b", content, re.MULTILINE):
+        content = re.sub(
+            r"^import importlib\n",
+            "import importlib\nimport os\n",
+            content,
+            count=1,
+        )
+        print("Patch 32: Added 'import os' to unverified_models.py")
+
+    target.write_text(content)
+    print("Patch 28/29/32: Successfully rewrote unverified_models.py")
+    return True
+
+
+def patch_30_model_info_region_prefix(build_dir: Path) -> bool:
+    """
+    Patch 30: Strip cross-region prefix in get_litellm_model_info fallback.
+
+    bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0 doesn't have a litellm
+    model_cost entry, but bedrock/anthropic.claude-3-7-sonnet-20250219-v1:0 does.
+    Add a 3rd fallback that re.subs ``bedrock/(us|eu|apac|global)\\.`` →
+    ``bedrock/`` so cross-region inference profile IDs resolve their cost / context
+    window metadata.
+    """
+    target = build_dir / "openhands-sdk/openhands/sdk/llm/utils/model_info.py"
+    if not target.exists():
+        print(f"ERROR: Patch 30 - File not found: {target}")
+        return False
+
+    content = target.read_text()
+
+    if "bedrock/(us|eu|apac|global)" in content:
+        print("Patch 30: Already applied (skipping)")
+        return True
+
+    # Insert a 3rd fallback before `return None` at the end of get_litellm_model_info.
+    anchor = (
+        "    try:\n"
+        "        model_info = get_model_info(model.split(\"/\")[-1])\n"
+        "        if model_info:\n"
+        "            return model_info\n"
+        "    except Exception:\n"
+        "        pass\n"
+        "\n"
+        "    return None"
+    )
     if anchor not in content:
-        print("ERROR: Patch 27a - Could not find o3 clamping anchor in llm.py")
+        print("ERROR: Patch 30 - Could not find tail anchor in get_litellm_model_info")
         return False
 
-    # Find the end of the o3 block (the closing of the if block)
-    anchor_pos = content.index(anchor)
-    # Find the next blank line after the o3 block
-    search_from = content.index('\n\n', anchor_pos)
+    new_block = (
+        "    try:\n"
+        "        model_info = get_model_info(model.split(\"/\")[-1])\n"
+        "        if model_info:\n"
+        "            return model_info\n"
+        "    except Exception:\n"
+        "        pass\n"
+        "\n"
+        "    # Patch 30 (openhands-infra): strip cross-region inference profile prefix\n"
+        "    # (us. / eu. / apac. / global.) so bedrock/us.anthropic.* resolves to the\n"
+        "    # underlying bedrock/anthropic.* model_cost entry.\n"
+        "    try:\n"
+        "        import re as _re\n"
+        "        stripped = _re.sub(r'^bedrock/(us|eu|apac|global)\\.', 'bedrock/', model)\n"
+        "        if stripped != model:\n"
+        "            model_info = get_model_info(stripped)\n"
+        "            if model_info:\n"
+        "                return model_info\n"
+        "    except Exception:\n"
+        "        pass\n"
+        "\n"
+        "    return None"
+    )
 
-    patch_27a = '''
+    content = content.replace(anchor, new_block, 1)
+    target.write_text(content)
+    print("Patch 30: Added cross-region prefix stripping fallback to get_litellm_model_info")
+    return True
 
-        # Patch 27 (openhands-infra): Bedrock models where litellm reports
-        # max_output_tokens == max_input_tokens are using the context window size,
-        # not the actual output limit. Reset to None so the Bedrock API uses
-        # the model's own default (per AWS docs, omitting maxTokens defaults to
-        # the model's maximum).
-        if self.model.startswith("bedrock/"):
-            _bad_output_limit = (
-                self.max_output_tokens is not None
-                and self.max_input_tokens is not None
-                and self.max_output_tokens == self.max_input_tokens
-            )
-            if self.max_output_tokens is None or _bad_output_limit:
-                if _bad_output_limit:
-                    logger.debug(
-                        "Patch 27: Bedrock model %s has max_output_tokens (%d) "
-                        "equal to max_input_tokens — likely context window. "
-                        "Resetting to None.",
-                        self.model,
-                        self.max_output_tokens,
-                    )
-                self.max_output_tokens = None
-'''
 
-    content = content[:search_from] + patch_27a + content[search_from:]
-    llm_file.write_text(content)
-    print("Patch 27a: Added Bedrock max_output_tokens context-window detection to llm.py")
+def patch_31_aws_default_region(build_dir: Path) -> bool:
+    """
+    Patch 31: Set AWS_DEFAULT_REGION alongside AWS_REGION_NAME.
 
-    # Part B: Patch chat_options.py — omit max_completion_tokens=None for Bedrock
-    chat_options_file = build_dir / "openhands-sdk/openhands/sdk/llm/options/chat_options.py"
-
-    if not chat_options_file.exists():
-        print(f"ERROR: Patch 27b - File not found: {chat_options_file}")
+    boto3 prefers AWS_DEFAULT_REGION for some auth modes (notably IAM Identity
+    Center / SSO and certain metadata-service paths). The SDK only sets
+    AWS_REGION_NAME, leaving boto3 unable to resolve a region in those modes.
+    """
+    target = build_dir / "openhands-sdk/openhands/sdk/llm/llm.py"
+    if not target.exists():
+        print(f"ERROR: Patch 31 - File not found: {target}")
         return False
 
-    opts_content = chat_options_file.read_text()
+    content = target.read_text()
 
-    # Insert after the Azure max_tokens handling block
-    azure_anchor = '            out["max_tokens"] = out.pop("max_completion_tokens")'
-    if azure_anchor not in opts_content:
-        print("ERROR: Patch 27b - Could not find Azure max_tokens anchor in chat_options.py")
+    if 'os.environ.setdefault("AWS_DEFAULT_REGION"' in content:
+        print("Patch 31: Already applied (skipping)")
+        return True
+
+    anchor = (
+        '        if self.aws_region_name:\n'
+        '            os.environ["AWS_REGION_NAME"] = self.aws_region_name\n'
+    )
+    if anchor not in content:
+        print("ERROR: Patch 31 - Could not find AWS_REGION_NAME anchor in _set_env_side_effects")
         return False
 
-    patch_27b = '''
-
-    # Patch 27 (openhands-infra): For Bedrock models with unknown max_output_tokens,
-    # remove max_completion_tokens entirely so the Bedrock API uses the model's own
-    # maximum (safest default for coding agents).
-    if llm.model.startswith("bedrock/") and out.get("max_completion_tokens") is None:
-        out.pop("max_completion_tokens", None)
-'''
-
-    # Find the line after the Azure block
-    azure_end = opts_content.index(azure_anchor) + len(azure_anchor)
-    # Find the next newline
-    next_newline = opts_content.index('\n', azure_end)
-    opts_content = opts_content[:next_newline + 1] + patch_27b + opts_content[next_newline + 1:]
-
-    chat_options_file.write_text(opts_content)
-    print("Patch 27b: Added Bedrock max_completion_tokens=None removal to chat_options.py")
-
-    print("Patch 27: Successfully patched both llm.py and chat_options.py")
+    new_block = (
+        '        if self.aws_region_name:\n'
+        '            os.environ["AWS_REGION_NAME"] = self.aws_region_name\n'
+        '            # Patch 31 (openhands-infra): boto3 prefers AWS_DEFAULT_REGION\n'
+        '            # over AWS_REGION_NAME for some auth modes (IAM Identity\n'
+        '            # Center / SSO, EC2 metadata service in certain configs).\n'
+        '            # Use setdefault so an explicit env var still wins.\n'
+        '            os.environ.setdefault("AWS_DEFAULT_REGION", self.aws_region_name)\n'
+    )
+    content = content.replace(anchor, new_block, 1)
+    target.write_text(content)
+    print("Patch 31: Added AWS_DEFAULT_REGION setdefault in _set_env_side_effects")
     return True
 
 
@@ -451,10 +626,14 @@ def main():
 
     # Apply all patches
     results.append(("Patch 23", patch_23_agent_context(build_dir)))
-    # Patch 24 removed — SDK v1.15.0 already uses model_dump(mode="json")
+    # Patch 24 removed — SDK v1.15.0+ already uses model_dump(mode="json")
     results.append(("Patch 25", patch_25_json_preprocessing(build_dir)))
     results.append(("Patch 26", patch_26_conversation_state(build_dir)))
-    results.append(("Patch 27", patch_27_bedrock_max_output_tokens(build_dir)))
+    # Patch 27 removed — SDK v1.19.1 caps max_output_tokens to half the context
+    # window (llm.py:1273-1287). Same outcome via different mechanism.
+    results.append(("Patch 28/29/32", patch_28_29_32_bedrock_listing(build_dir)))
+    results.append(("Patch 30", patch_30_model_info_region_prefix(build_dir)))
+    results.append(("Patch 31", patch_31_aws_default_region(build_dir)))
 
     print()
     print("=" * 60)

--- a/docker/apply-startup.sh
+++ b/docker/apply-startup.sh
@@ -238,30 +238,50 @@ if [ -f "$APP_CONFIG_FILE" ]; then
   fi
 fi
 
-# ─── Patch 21: Verify multi-tenant store configuration ──────────────────────
+# ─── Patch 21: Verify multi-tenant store configuration (V1 paths) ───────────
+#
+# v1.7.0 deleted the V0 server_config.py store-class fields. Multi-tenant store
+# wiring now lives in /app/openhands/app_server/config.py, where the fork patches
+# the conversation_info, settings, and secrets injectors to Cognito-aware
+# subclasses under openhands.app_server.{user_auth,settings,secrets}.
+#
+# This check is FAIL-CLOSED: if the V1 config file is missing the expected
+# CognitoS3 store wiring, the container refuses to start. The failure mode of a
+# silent pass-through (e.g. grepping a deleted V0 file via `if [ -f ... ]`)
+# would let settings/secrets fall back to a shared key, which is a multi-tenant
+# isolation breach.
 
-SERVER_CONFIG_FILE="/app/openhands/server/config/server_config.py"
-if [ -f "$SERVER_CONFIG_FILE" ]; then
+if [ ! -f "$APP_CONFIG_FILE" ]; then
+  echo "CRITICAL: $APP_CONFIG_FILE not found — V1 config required by v1.7.0+" >&2
+  mark_critical_failure "Patch21-app-config-missing"
+else
   MISSING_STORES=""
 
-  if grep -q "s3_settings_store.S3SettingsStore" "$SERVER_CONFIG_FILE"; then
-    echo "Patch 21: S3SettingsStore configured correctly"
+  if grep -qE "CognitoS3SettingsStore|cognito_s3_settings_store" "$APP_CONFIG_FILE"; then
+    echo "Patch 21: CognitoS3SettingsStore wired in app_server/config.py"
   else
-    echo "WARNING: S3SettingsStore not configured - settings may not be user-scoped" >&2
-    MISSING_STORES="${MISSING_STORES} S3SettingsStore"
+    echo "CRITICAL: CognitoS3SettingsStore not wired — settings may not be user-scoped" >&2
+    MISSING_STORES="${MISSING_STORES} CognitoS3SettingsStore"
   fi
 
-  if grep -q "s3_secrets_store.S3SecretsStore" "$SERVER_CONFIG_FILE"; then
-    echo "Patch 21: S3SecretsStore configured correctly"
+  if grep -qE "CognitoS3SecretsStore|cognito_s3_secrets_store" "$APP_CONFIG_FILE"; then
+    echo "Patch 21: CognitoS3SecretsStore wired in app_server/config.py"
   else
-    echo "WARNING: S3SecretsStore not configured - secrets may not be user-scoped" >&2
-    MISSING_STORES="${MISSING_STORES} S3SecretsStore"
+    echo "CRITICAL: CognitoS3SecretsStore not wired — secrets may not be user-scoped" >&2
+    MISSING_STORES="${MISSING_STORES} CognitoS3SecretsStore"
+  fi
+
+  if grep -qE "CognitoUserAuth|cognito_user_auth" "$APP_CONFIG_FILE"; then
+    echo "Patch 21: CognitoUserAuth wired in app_server/config.py"
+  else
+    echo "CRITICAL: CognitoUserAuth not wired — auth may fall back to default user" >&2
+    MISSING_STORES="${MISSING_STORES} CognitoUserAuth"
   fi
 
   if [ -z "$MISSING_STORES" ]; then
-    echo "Patch 21: Multi-tenant isolation ENABLED - settings/secrets stored at users/{user_id}/"
+    echo "Patch 21: Multi-tenant isolation ENABLED — settings/secrets stored at users/{user_id}/"
   else
-    mark_critical_failure "Patch21-multi-tenant-isolation"
+    mark_critical_failure "Patch21-multi-tenant-isolation:${MISSING_STORES}"
   fi
 fi
 

--- a/docker/apply-startup.sh
+++ b/docker/apply-startup.sh
@@ -240,39 +240,50 @@ fi
 
 # ─── Patch 21: Verify multi-tenant store configuration (V1 paths) ───────────
 #
-# v1.7.0 deleted the V0 server_config.py store-class fields. Multi-tenant store
-# wiring now lives in /app/openhands/app_server/config.py, where the fork patches
-# the conversation_info, settings, and secrets injectors to Cognito-aware
-# subclasses under openhands.app_server.{user_auth,settings,secrets}.
+# In v1.7.0, the V1 store wiring lives in TWO places:
 #
-# This check is FAIL-CLOSED: if the V1 config file is missing the expected
-# CognitoS3 store wiring, the container refuses to start. The failure mode of a
-# silent pass-through (e.g. grepping a deleted V0 file via `if [ -f ... ]`)
-# would let settings/secrets fall back to a shared key, which is a multi-tenant
-# isolation breach.
+#   1. /app/openhands/server/config/server_config.py:
+#      settings_store_class / secret_store_class / user_auth_class string fields
+#      drive get_impl() in openhands.server.shared. The fork patches these to
+#      point at openhands.app_server.{settings,secrets,user_auth}.<cognito_*>.
+#      This file is V0-tagged but its store-class fields are still active.
+#
+#   2. /app/openhands/app_server/config.py:
+#      CognitoSQLAppConversationInfoServiceInjector — multi-tenant conversation
+#      isolation (verified above).
+#
+# This check is FAIL-CLOSED: if any of the three string-class fields are
+# missing the Cognito V1 wiring, the container refuses to start. The previous
+# v1.6.0 grep on s3_settings_store.S3SettingsStore (V0 paths) silently passed
+# when the V0 file was deleted in v1.7.0 — that's the failure mode this
+# rewrite closes.
 
-if [ ! -f "$APP_CONFIG_FILE" ]; then
-  echo "CRITICAL: $APP_CONFIG_FILE not found — V1 config required by v1.7.0+" >&2
-  mark_critical_failure "Patch21-app-config-missing"
+SERVER_CONFIG_FILE="/app/openhands/server/config/server_config.py"
+if [ ! -f "$SERVER_CONFIG_FILE" ]; then
+  echo "CRITICAL: $SERVER_CONFIG_FILE not found — required for V1 store wiring" >&2
+  mark_critical_failure "Patch21-server-config-missing"
 else
   MISSING_STORES=""
 
-  if grep -qE "CognitoS3SettingsStore|cognito_s3_settings_store" "$APP_CONFIG_FILE"; then
-    echo "Patch 21: CognitoS3SettingsStore wired in app_server/config.py"
+  # Tolerate either filename form (s3_settings_store.py or
+  # cognito_s3_settings_store.py) so a future rename inside the fork doesn't
+  # silently bypass this check.
+  if grep -qE "(cognito_)?s3_settings_store\.CognitoS3SettingsStore" "$SERVER_CONFIG_FILE"; then
+    echo "Patch 21: CognitoS3SettingsStore wired in server_config.py"
   else
     echo "CRITICAL: CognitoS3SettingsStore not wired — settings may not be user-scoped" >&2
     MISSING_STORES="${MISSING_STORES} CognitoS3SettingsStore"
   fi
 
-  if grep -qE "CognitoS3SecretsStore|cognito_s3_secrets_store" "$APP_CONFIG_FILE"; then
-    echo "Patch 21: CognitoS3SecretsStore wired in app_server/config.py"
+  if grep -qE "(cognito_)?s3_secrets_store\.CognitoS3SecretsStore" "$SERVER_CONFIG_FILE"; then
+    echo "Patch 21: CognitoS3SecretsStore wired in server_config.py"
   else
     echo "CRITICAL: CognitoS3SecretsStore not wired — secrets may not be user-scoped" >&2
     MISSING_STORES="${MISSING_STORES} CognitoS3SecretsStore"
   fi
 
-  if grep -qE "CognitoUserAuth|cognito_user_auth" "$APP_CONFIG_FILE"; then
-    echo "Patch 21: CognitoUserAuth wired in app_server/config.py"
+  if grep -qE "cognito_user_auth\.CognitoUserAuth" "$SERVER_CONFIG_FILE"; then
+    echo "Patch 21: CognitoUserAuth wired in server_config.py"
   else
     echo "CRITICAL: CognitoUserAuth not wired — auth may fall back to default user" >&2
     MISSING_STORES="${MISSING_STORES} CognitoUserAuth"

--- a/docker/cognito_user_auth.py
+++ b/docker/cognito_user_auth.py
@@ -23,14 +23,20 @@ V1 NOTES (PR #81 / OpenHands v1.7.0):
   Legacy-V0-tagged files (see openhands/app_server/user/auth_user_context.py
   which wraps UserAuth as the V1 UserContext).
 - Settings model moved to openhands.app_server.settings.settings_models.
-- MCPSSEServerConfig / MCPStdioServerConfig live in openhands.core.config
-  in v1.7.0 (unchanged from v1.6.0).
+- MCP config moved from Settings.mcp_config (V0) to
+  Settings.agent_settings.mcp_config (V1) using fastmcp's MCPConfig shape:
+  ``{'mcpServers': {'name': {'url': ...}|{'command':..., 'args': [...]}}}``
+- V1's app_server does NOT parse config.toml's [mcp] section. We load it
+  here at user-settings time and inject into agent_settings.mcp_config so
+  global servers (knowledge-mcp, chrome-devtools-mcp) reach the agent.
 """
 
 import logging
 import os
+import tomllib
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from fastapi import Request
 
@@ -44,6 +50,73 @@ logger = logging.getLogger(__name__)
 
 # Feature flag for user config loading
 USER_CONFIG_ENABLED = os.environ.get('USER_CONFIG_ENABLED', 'false').lower() == 'true'
+
+# Path to the global app config.toml. The compute-stack writes config.toml content
+# from the OPENHANDS_CONFIG_TOML env var into /app/config.toml at container start.
+GLOBAL_CONFIG_TOML_PATH = Path(os.environ.get('OPENHANDS_CONFIG_PATH', '/app/config.toml'))
+
+
+def _load_global_mcp_servers() -> dict[str, dict[str, Any]]:
+    """Parse [mcp] from the global config.toml into fastmcp mcpServers shape.
+
+    Returns a dict of ``{name: server_dict}`` ready to merge into
+    ``Settings.agent_settings.mcp_config.mcpServers``. Each server_dict is
+    either ``{'url': '...'}`` (HTTP) or ``{'command': '...', 'args': [...]}``
+    (stdio), matching fastmcp's MCPConfig schema.
+
+    Returns an empty dict if the file is missing, unreadable, or has no [mcp]
+    section. Reading config.toml is best-effort; failures are logged but
+    must not block user settings load.
+    """
+    try:
+        if not GLOBAL_CONFIG_TOML_PATH.exists():
+            return {}
+        with GLOBAL_CONFIG_TOML_PATH.open('rb') as f:
+            data = tomllib.load(f)
+    except Exception as e:
+        logger.warning(f'Failed to read global config.toml at {GLOBAL_CONFIG_TOML_PATH}: {e}')
+        return {}
+
+    mcp_section = data.get('mcp') or {}
+    servers: dict[str, dict[str, Any]] = {}
+
+    # HTTP/SSE servers — config.toml uses `shttp_servers = [{ url = "..." }]`.
+    # fastmcp keys each server by name; derive a stable name from the URL host
+    # when one isn't provided, since shttp entries typically lack a name field.
+    for entry in mcp_section.get('shttp_servers') or []:
+        url = entry.get('url')
+        if not url:
+            continue
+        name = entry.get('name') or _name_from_url(url)
+        servers[name] = {'url': url}
+
+    # stdio servers — `[{ name, command, args, env }]`
+    for entry in mcp_section.get('stdio_servers') or []:
+        name = entry.get('name')
+        command = entry.get('command')
+        if not name or not command:
+            continue
+        server_dict: dict[str, Any] = {'command': command, 'args': list(entry.get('args') or [])}
+        env = entry.get('env')
+        if env:
+            server_dict['env'] = dict(env)
+        servers[name] = server_dict
+
+    return servers
+
+
+def _name_from_url(url: str) -> str:
+    """Derive a stable MCP server name from a URL when none is given.
+
+    Uses the host's first label, e.g. ``https://knowledge-mcp.global.api.aws``
+    -> ``knowledge-mcp``. Falls back to the full URL if parsing fails.
+    """
+    try:
+        from urllib.parse import urlparse
+        host = urlparse(url).hostname or url
+        return host.split('.')[0] or url
+    except Exception:
+        return url
 
 
 @dataclass
@@ -93,16 +166,28 @@ class CognitoUserAuth(DefaultUserAuth):
         return instance
 
     async def get_user_settings(self) -> 'Settings | None':
-        """Get user settings with user-specific MCP configuration merged in.
+        """Get user settings with global + per-user MCP servers merged in.
 
-        Loads base settings via the parent (which already merges config.toml),
-        then applies the per-user MCP overlay from S3: removes globally
-        configured servers the user has disabled, appends the user's custom
-        shttp/stdio servers, and registers any auto_mcp servers configured by
-        third-party integrations.
+        V1 architecture: MCP config lives at
+        ``settings.agent_settings.mcp_config`` (fastmcp's MCPConfig with
+        ``mcpServers: dict[str, MCPServer]``). The V1 app_server does NOT
+        load config.toml's [mcp] section, so we do it here ourselves and
+        merge it with per-user S3 overlays.
+
+        Merge order (later wins on name collision):
+          1. Global ``[mcp]`` from ``/app/config.toml``
+          2. User-disabled global servers are removed
+          3. Per-user custom servers from S3
+          4. auto_mcp servers from user integrations
         """
-        # Get base settings from parent (includes config.toml merge)
+        # Get base settings from parent
         settings = await super().get_user_settings()
+
+        # Load global config.toml [mcp] for every authenticated user
+        # (V1 doesn't do this automatically — see module docstring).
+        global_servers = _load_global_mcp_servers()
+        if global_servers:
+            settings = self._ensure_mcp_servers(settings, global_servers)
 
         if not USER_CONFIG_ENABLED:
             return settings
@@ -112,7 +197,6 @@ class CognitoUserAuth(DefaultUserAuth):
             return settings
 
         try:
-            # Import here to avoid circular imports
             from user_config_loader import UserConfigLoader
             try:
                 from user_config_loader import INTEGRATION_MCP_MAP
@@ -121,62 +205,59 @@ class CognitoUserAuth(DefaultUserAuth):
                 INTEGRATION_MCP_MAP = {}
 
             loader = UserConfigLoader(user_id)
+            user_mcp = loader.get_mcp_config() or {}
 
-            # Load user MCP configuration
-            user_mcp = loader.get_mcp_config()
-            if user_mcp and settings and settings.mcp_config:
-                # Remove user-disabled global servers
-                disabled = set(user_mcp.get('disabled_global_servers', []))
-                if disabled:
-                    logger.info(f'User {user_id} disabled global MCP servers: {disabled}')
+            # Apply per-user disable list (drops names from the merged map)
+            disabled = set(user_mcp.get('disabled_global_servers') or [])
+            if disabled:
+                self._remove_mcp_servers(settings, disabled)
+                logger.info(f'User {user_id} disabled global MCP servers: {disabled}')
 
-                    settings.mcp_config.shttp_servers = [
-                        s for s in settings.mcp_config.shttp_servers
-                        if getattr(s, 'url', '') not in disabled
-                    ]
-                    settings.mcp_config.stdio_servers = [
-                        s for s in settings.mcp_config.stdio_servers
-                        if getattr(s, 'name', '') not in disabled
-                    ]
+            # Per-user custom shttp servers
+            user_servers: dict[str, dict[str, Any]] = {}
+            for server in user_mcp.get('shttp_servers') or []:
+                if not server.get('enabled', True):
+                    continue
+                url = server.get('url')
+                if not url:
+                    continue
+                name = server.get('name') or server.get('id') or _name_from_url(url)
+                user_servers[name] = {'url': url}
 
-                # Add user custom shttp servers
-                for server in user_mcp.get('shttp_servers', []):
-                    if server.get('enabled', True):
-                        from openhands.core.config.mcp_config import MCPSSEServerConfig
-                        settings.mcp_config.sse_servers = list(settings.mcp_config.sse_servers) + [
-                            MCPSSEServerConfig(url=server['url'])
-                        ]
+            # Per-user custom stdio servers
+            for server in user_mcp.get('stdio_servers') or []:
+                if not server.get('enabled', True):
+                    continue
+                name = server.get('name') or server.get('id')
+                command = server.get('command')
+                if not name or not command:
+                    continue
+                server_dict: dict[str, Any] = {
+                    'command': command,
+                    'args': list(server.get('args') or []),
+                }
+                if server.get('env'):
+                    server_dict['env'] = dict(server['env'])
+                user_servers[name] = server_dict
 
-                # Add user custom stdio servers
-                for server in user_mcp.get('stdio_servers', []):
-                    if server.get('enabled', True):
-                        from openhands.core.config.mcp_config import MCPStdioServerConfig
-                        settings.mcp_config.stdio_servers = list(settings.mcp_config.stdio_servers) + [
-                            MCPStdioServerConfig(
-                                name=server.get('name', server.get('id')),
-                                command=server.get('command', ''),
-                                args=server.get('args', []),
-                                env=server.get('env', {}),
-                            )
-                        ]
-
-            # Load integrations and add auto_mcp servers
+            # auto_mcp servers from user integrations
             integrations = loader.get_integrations()
             for provider, config in integrations.items():
-                if config.get('enabled') and config.get('auto_mcp', True):
-                    mcp_template = INTEGRATION_MCP_MAP.get(provider)
-                    if mcp_template and settings and settings.mcp_config:
-                        from openhands.core.config.mcp_config import MCPStdioServerConfig
-                        settings.mcp_config.stdio_servers = list(settings.mcp_config.stdio_servers) + [
-                            MCPStdioServerConfig(
-                                name=mcp_template['name'],
-                                command=mcp_template['command'],
-                                args=mcp_template['args'],
-                                env={
-                                    f"{mcp_template['env_key']}_REF": config.get('token_ref', '')
-                                },
-                            )
-                        ]
+                if not (config.get('enabled') and config.get('auto_mcp', True)):
+                    continue
+                template = INTEGRATION_MCP_MAP.get(provider)
+                if not template:
+                    continue
+                user_servers[template['name']] = {
+                    'command': template['command'],
+                    'args': list(template['args']),
+                    'env': {
+                        f"{template['env_key']}_REF": config.get('token_ref', '')
+                    },
+                }
+
+            if user_servers:
+                settings = self._ensure_mcp_servers(settings, user_servers)
 
         except ImportError as e:
             logger.warning(f'User config loader not available: {e}')
@@ -184,3 +265,42 @@ class CognitoUserAuth(DefaultUserAuth):
             logger.error(f'Failed to load user MCP config: {e}')
 
         return settings
+
+    @staticmethod
+    def _ensure_mcp_servers(
+        settings: 'Settings | None', servers: dict[str, dict[str, Any]]
+    ) -> 'Settings | None':
+        """Merge ``servers`` into ``settings.agent_settings.mcp_config.mcpServers``.
+
+        Creates the ``mcp_config`` if it's missing. Existing servers with the
+        same name are overwritten — caller orders the merge accordingly.
+        """
+        if settings is None or settings.agent_settings is None:
+            return settings
+        from fastmcp.mcp_config import MCPConfig
+
+        agent_settings = settings.agent_settings
+        existing = agent_settings.mcp_config
+        existing_dict = existing.model_dump(exclude_none=True) if existing else {}
+        existing_servers = dict(existing_dict.get('mcpServers') or {})
+        existing_servers.update(servers)
+        existing_dict['mcpServers'] = existing_servers
+        agent_settings.mcp_config = MCPConfig.from_dict(existing_dict)
+        return settings
+
+    @staticmethod
+    def _remove_mcp_servers(
+        settings: 'Settings | None', names: set[str]
+    ) -> None:
+        """Remove named servers from ``settings.agent_settings.mcp_config.mcpServers``."""
+        if (
+            settings is None
+            or settings.agent_settings is None
+            or settings.agent_settings.mcp_config is None
+        ):
+            return
+        mcp = settings.agent_settings.mcp_config
+        if not mcp.mcpServers:
+            return
+        for name in names:
+            mcp.mcpServers.pop(name, None)

--- a/docker/cognito_user_auth.py
+++ b/docker/cognito_user_auth.py
@@ -1,5 +1,5 @@
 """
-Cognito User Authentication for OpenHands
+Cognito User Authentication for OpenHands (V1).
 
 This module provides user authentication via AWS Cognito, integrating with
 Lambda@Edge which injects verified user information as HTTP headers.
@@ -15,6 +15,16 @@ User Configuration:
     - Add custom MCP servers (shttp or stdio)
     - Disable specific global MCP servers
     - Configure third-party integrations with auto_mcp support
+
+V1 NOTES (PR #81 / OpenHands v1.7.0):
+- Imports moved from openhands.server.user_auth.* to
+  openhands.app_server.user_auth.* — V0 paths are scheduled for removal
+  but the V1 application server still routes auth through these
+  Legacy-V0-tagged files (see openhands/app_server/user/auth_user_context.py
+  which wraps UserAuth as the V1 UserContext).
+- Settings model moved to openhands.app_server.settings.settings_models.
+- MCPSSEServerConfig / MCPStdioServerConfig live in openhands.core.config
+  in v1.7.0 (unchanged from v1.6.0).
 """
 
 import logging
@@ -24,11 +34,11 @@ from typing import TYPE_CHECKING
 
 from fastapi import Request
 
-from openhands.server.user_auth.default_user_auth import DefaultUserAuth
-from openhands.server.user_auth.user_auth import UserAuth
+from openhands.app_server.user_auth.default_user_auth import DefaultUserAuth
+from openhands.app_server.user_auth.user_auth import UserAuth
 
 if TYPE_CHECKING:
-    from openhands.storage.data_models.settings import Settings
+    from openhands.app_server.settings.settings_models import Settings
 
 logger = logging.getLogger(__name__)
 
@@ -49,19 +59,9 @@ class CognitoUserAuth(DefaultUserAuth):
     _email: str | None = None
 
     async def get_user_id(self) -> str | None:
-        """Return the Cognito user ID (sub claim from JWT).
-
-        Returns:
-            The user's Cognito sub (unique identifier) or None if not authenticated.
-        """
         return self._user_id
 
     async def get_user_email(self) -> str | None:
-        """Return the user's email from Cognito.
-
-        Returns:
-            The user's email address or None if not available.
-        """
         return self._email
 
     @classmethod
@@ -71,13 +71,6 @@ class CognitoUserAuth(DefaultUserAuth):
         Extracts user information from headers set by Lambda@Edge:
         - x-cognito-user-id: The user's Cognito sub (unique identifier)
         - x-cognito-email: The user's email address
-
-        Args:
-            request: The FastAPI request object.
-
-        Returns:
-            A CognitoUserAuth instance with user info, or DefaultUserAuth
-            if no valid Cognito headers are present.
         """
         user_id = request.headers.get('x-cognito-user-id')
         email = request.headers.get('x-cognito-email')
@@ -85,52 +78,32 @@ class CognitoUserAuth(DefaultUserAuth):
         logger.info(f"CognitoUserAuth.get_instance: user_id={user_id}, email={email}")
 
         if not user_id:
-            # No Cognito user info, fall back to default behavior
             logger.info("CognitoUserAuth: No user_id in headers, using DefaultUserAuth")
             return DefaultUserAuth()
 
         instance = cls()
         instance._user_id = user_id
         instance._email = email if email else None
-        logger.info(f"CognitoUserAuth: Created instance for user {user_id}")
         return instance
 
     @classmethod
     async def get_for_user(cls, user_id: str) -> UserAuth:
-        """Create an instance for a specific user ID.
-
-        Used internally when user context is needed without a request.
-
-        Args:
-            user_id: The Cognito user ID (sub).
-
-        Returns:
-            A CognitoUserAuth instance with the specified user ID.
-        """
         instance = cls()
         instance._user_id = user_id
         return instance
 
     async def get_user_settings(self) -> 'Settings | None':
-        """Get user settings with merged MCP configuration.
+        """Get user settings with user-specific MCP configuration merged in.
 
-        This method extends the parent's settings loading to include
-        user-specific MCP configuration from S3. The merge process:
-        1. Load base settings (with config.toml merge) from parent
-        2. Load user MCP config from S3
-        3. Remove disabled global servers
-        4. Add user custom servers
-        5. Add auto_mcp servers from integrations
-
-        Returns:
-            Settings with merged MCP configuration, or None if not found.
+        Loads base settings via the parent (which already merges config.toml),
+        then applies the per-user MCP overlay from S3: removes globally
+        configured servers the user has disabled, appends the user's custom
+        shttp/stdio servers, and registers any auto_mcp servers configured by
+        third-party integrations.
         """
-        from openhands.storage.data_models.settings import Settings
-
         # Get base settings from parent (includes config.toml merge)
         settings = await super().get_user_settings()
 
-        # Check if user config loading is enabled
         if not USER_CONFIG_ENABLED:
             return settings
 
@@ -157,7 +130,6 @@ class CognitoUserAuth(DefaultUserAuth):
                 if disabled:
                     logger.info(f'User {user_id} disabled global MCP servers: {disabled}')
 
-                    # Filter out disabled servers by URL (for shttp) or name (for stdio)
                     settings.mcp_config.shttp_servers = [
                         s for s in settings.mcp_config.shttp_servers
                         if getattr(s, 'url', '') not in disabled
@@ -174,7 +146,6 @@ class CognitoUserAuth(DefaultUserAuth):
                         settings.mcp_config.sse_servers = list(settings.mcp_config.sse_servers) + [
                             MCPSSEServerConfig(url=server['url'])
                         ]
-                        logger.info(f'Added user shttp MCP server: {server.get("id")}')
 
                 # Add user custom stdio servers
                 for server in user_mcp.get('stdio_servers', []):
@@ -188,7 +159,6 @@ class CognitoUserAuth(DefaultUserAuth):
                                 env=server.get('env', {}),
                             )
                         ]
-                        logger.info(f'Added user stdio MCP server: {server.get("id")}')
 
             # Load integrations and add auto_mcp servers
             integrations = loader.get_integrations()
@@ -207,7 +177,6 @@ class CognitoUserAuth(DefaultUserAuth):
                                 },
                             )
                         ]
-                        logger.info(f'Added auto_mcp server for integration: {provider}')
 
         except ImportError as e:
             logger.warning(f'User config loader not available: {e}')

--- a/docker/cognito_user_auth.py
+++ b/docker/cognito_user_auth.py
@@ -175,10 +175,14 @@ class CognitoUserAuth(DefaultUserAuth):
         merge it with per-user S3 overlays.
 
         Merge order (later wins on name collision):
-          1. Global ``[mcp]`` from ``/app/config.toml``
-          2. User-disabled global servers are removed
-          3. Per-user custom servers from S3
-          4. auto_mcp servers from user integrations
+          1. Global ``[mcp]`` servers from ``/app/config.toml`` are merged.
+          2. ``disabled_global_servers`` removes the named entries from the
+             merged map. This is intentionally scoped to globals — disabling
+             a name is applied BEFORE per-user/integration servers are added,
+             so a user's own server with the same name will still be present
+             in the final config.
+          3. Per-user custom shttp/stdio servers from S3 are merged in.
+          4. auto_mcp servers from user integrations are merged in last.
         """
         # Get base settings from parent
         settings = await super().get_user_settings()
@@ -273,7 +277,8 @@ class CognitoUserAuth(DefaultUserAuth):
         """Merge ``servers`` into ``settings.agent_settings.mcp_config.mcpServers``.
 
         Creates the ``mcp_config`` if it's missing. Existing servers with the
-        same name are overwritten — caller orders the merge accordingly.
+        same name are overwritten — caller orders the merge accordingly. Logs
+        a warning on overwrite so silent shadowing is visible in operator logs.
         """
         if settings is None or settings.agent_settings is None:
             return settings
@@ -283,6 +288,8 @@ class CognitoUserAuth(DefaultUserAuth):
         existing = agent_settings.mcp_config
         existing_dict = existing.model_dump(exclude_none=True) if existing else {}
         existing_servers = dict(existing_dict.get('mcpServers') or {})
+        for name in servers.keys() & existing_servers.keys():
+            logger.warning(f'MCP server name collision — overwriting existing: {name}')
         existing_servers.update(servers)
         existing_dict['mcpServers'] = existing_servers
         agent_settings.mcp_config = MCPConfig.from_dict(existing_dict)

--- a/docker/download-fork-patches.sh
+++ b/docker/download-fork-patches.sh
@@ -6,19 +6,50 @@
 #
 # Environment variables:
 #   FORK_REPO  - GitHub org/repo (default: zxkane/openhands)
-#   FORK_REF   - Branch or tag   (default: custom-v1.6.0-fargate-r1)
+#   FORK_REF   - Branch or tag   (default: pinned commit SHA on custom/v1.7.0-fargate)
 set -e
 
 FORK_REPO="${FORK_REPO:-zxkane/openhands}"
-# Pin to commit SHA for reproducible builds (tag: custom-v1.6.0-fargate-r1)
-# Fargate branch: RemoteSandboxService compatible, multi-tenant isolation, Bedrock enhancements
-FORK_REF="${FORK_REF:-7a481ec3a7ec071851a3a854bd0c76b338c88e7b}"
+# Pin to commit SHA for reproducible builds (branch: custom/v1.7.0-fargate).
+# v1.7.0 brings the upstream V0 → V1 cleanup: openhands/llm/, openhands/utils/llm.py,
+# openhands/storage/, openhands/core/config/llm_config.py and several
+# openhands/server/config/server_config.py fields are deleted upstream. The fork
+# moves those patches into the SDK fork (see docker/agent-server-custom/apply-sdk-patches.py)
+# or onto V1 paths under openhands/app_server/.
+#
+# TODO(PR #81): pin to the final SHA of custom/v1.7.0-fargate once the fork branch
+# is complete. The current value is the partial cherry-pick checkpoint (17/20
+# commits ported from custom-v1.6.0-fargate-r1).
+FORK_REF="${FORK_REF:-b707ea5cc1a410e9dd26058071a260188da99fc9}"
 BASE_URL="https://raw.githubusercontent.com/${FORK_REPO}/${FORK_REF}"
 
-# 14 upstream Python files modified in the fork (verified via GitHub compare API:
-# gh api repos/zxkane/openhands/compare/<upstream-1.6.0-sha>...<fork-ref>)
+# Files modified in the v1.7.0 fork branch (verified via GitHub compare API:
+# gh api repos/zxkane/openhands/compare/<upstream-1.7.0-sha>...<fork-ref>)
 # Do NOT add files here that are not in the fork diff — the base image already has them.
 # Adding unmodified upstream files can break compatibility when the base image updates.
+#
+# Files dropped from v1.6.0 → v1.7.0 (logic moved to SDK fork or removed because
+# the upstream V0 surface no longer exists):
+#   - openhands/server/config/server_config.py     (V0 store-class fields removed upstream)
+#   - openhands/storage/data_models/secrets.py     (storage package collapse — no V1 home needed)
+#   - openhands/llm/bedrock.py                     (entire openhands/llm/ package deleted)
+#   - openhands/llm/llm.py                         (same)
+#   - openhands/core/config/llm_config.py          (deleted; AWS_DEFAULT_REGION moved to SDK Patch 31)
+#   - openhands/utils/llm.py                       (moved upstream to app_server/utils/llm.py;
+#                                                   env-hint detection moved to SDK Patch 32)
+#
+# Files added net-new for v1.7.0 (V1 ports of V0 Cognito / S3 stores; these don't
+# exist upstream — the fork branch must create them under openhands/app_server/).
+# They are intentionally NOT in FILES yet because the fork branch is still in
+# progress (only 17/20 v1.6.0 commits cherry-picked; V1 store ports pending).
+# Add the lines below once the fork branch creates them and FORK_REF is bumped:
+#
+#   openhands/app_server/user_auth/cognito_user_auth.py
+#   openhands/app_server/settings/cognito_s3_settings_store.py
+#   openhands/app_server/secrets/cognito_s3_secrets_store.py
+#
+# When you add them, also rewrite Patch 21 in apply-startup.sh to grep for the
+# new V1 paths (V0 grep for s3_settings_store.S3SettingsStore would silently pass).
 FILES="
 openhands/app_server/sandbox/remote_sandbox_service.py
 openhands/app_server/app_conversation/app_conversation_service.py
@@ -26,14 +57,8 @@ openhands/app_server/app_conversation/live_status_app_conversation_service.py
 openhands/app_server/app_conversation/app_conversation_router.py
 openhands/app_server/event_callback/webhook_router.py
 openhands/app_server/services/db_session_injector.py
-openhands/server/config/server_config.py
-openhands/storage/data_models/secrets.py
 openhands/app_server/config.py
 openhands/app_server/event_callback/sql_event_callback_service.py
-openhands/llm/bedrock.py
-openhands/llm/llm.py
-openhands/utils/llm.py
-openhands/core/config/llm_config.py
 "
 
 FAILED=""

--- a/docker/download-fork-patches.sh
+++ b/docker/download-fork-patches.sh
@@ -12,15 +12,13 @@ set -e
 FORK_REPO="${FORK_REPO:-zxkane/openhands}"
 # Pin to commit SHA for reproducible builds (branch: custom/v1.7.0-fargate).
 # v1.7.0 brings the upstream V0 → V1 cleanup: openhands/llm/, openhands/utils/llm.py,
-# openhands/storage/, openhands/core/config/llm_config.py and several
-# openhands/server/config/server_config.py fields are deleted upstream. The fork
-# moves those patches into the SDK fork (see docker/agent-server-custom/apply-sdk-patches.py)
-# or onto V1 paths under openhands/app_server/.
-#
-# TODO(PR #81): pin to the final SHA of custom/v1.7.0-fargate once the fork branch
-# is complete. The current value is the partial cherry-pick checkpoint (17/20
-# commits ported from custom-v1.6.0-fargate-r1).
-FORK_REF="${FORK_REF:-b707ea5cc1a410e9dd26058071a260188da99fc9}"
+# openhands/storage/, openhands/core/config/llm_config.py are deleted upstream.
+# The fork moves the deleted-V0 patches into:
+#   - SDK patches (apply-sdk-patches.py: Patches 28-32 for Bedrock features)
+#   - V1 custom modules COPY'd by Dockerfile (cognito_user_auth.py,
+#     s3_settings_store.py, s3_secrets_store.py — these don't go through this
+#     download because they live in openhands-infra/docker/, not upstream)
+FORK_REF="${FORK_REF:-4e480e79c47fb4c66c94c8176d130abdd6d5d2e9}"
 BASE_URL="https://raw.githubusercontent.com/${FORK_REPO}/${FORK_REF}"
 
 # Files modified in the v1.7.0 fork branch (verified via GitHub compare API:
@@ -28,28 +26,26 @@ BASE_URL="https://raw.githubusercontent.com/${FORK_REPO}/${FORK_REF}"
 # Do NOT add files here that are not in the fork diff — the base image already has them.
 # Adding unmodified upstream files can break compatibility when the base image updates.
 #
-# Files dropped from v1.6.0 → v1.7.0 (logic moved to SDK fork or removed because
-# the upstream V0 surface no longer exists):
-#   - openhands/server/config/server_config.py     (V0 store-class fields removed upstream)
-#   - openhands/storage/data_models/secrets.py     (storage package collapse — no V1 home needed)
-#   - openhands/llm/bedrock.py                     (entire openhands/llm/ package deleted)
-#   - openhands/llm/llm.py                         (same)
-#   - openhands/core/config/llm_config.py          (deleted; AWS_DEFAULT_REGION moved to SDK Patch 31)
-#   - openhands/utils/llm.py                       (moved upstream to app_server/utils/llm.py;
-#                                                   env-hint detection moved to SDK Patch 32)
+# Files dropped from v1.6.0 (logic moved to SDK fork or removed because the
+# upstream V0 surface no longer exists):
+#   - openhands/storage/data_models/secrets.py     (storage package collapse;
+#                                                   secret-resume validators moved
+#                                                   to SDK patches 23/25/26)
+#   - openhands/llm/bedrock.py                     (entire openhands/llm/ deleted;
+#                                                   logic moved to SDK Patches 28/29)
+#   - openhands/llm/llm.py                         (same; SDK Patch 30)
+#   - openhands/core/config/llm_config.py          (deleted; AWS_DEFAULT_REGION
+#                                                   moved to SDK Patch 31)
+#   - openhands/utils/llm.py                       (moved upstream to
+#                                                   app_server/utils/llm.py;
+#                                                   env-hint detection moved
+#                                                   to SDK Patch 32)
 #
-# Files added net-new for v1.7.0 (V1 ports of V0 Cognito / S3 stores; these don't
-# exist upstream — the fork branch must create them under openhands/app_server/).
-# They are intentionally NOT in FILES yet because the fork branch is still in
-# progress (only 17/20 v1.6.0 commits cherry-picked; V1 store ports pending).
-# Add the lines below once the fork branch creates them and FORK_REF is bumped:
-#
-#   openhands/app_server/user_auth/cognito_user_auth.py
-#   openhands/app_server/settings/cognito_s3_settings_store.py
-#   openhands/app_server/secrets/cognito_s3_secrets_store.py
-#
-# When you add them, also rewrite Patch 21 in apply-startup.sh to grep for the
-# new V1 paths (V0 grep for s3_settings_store.S3SettingsStore would silently pass).
+# Files retained for v1.7.0 (still patched on the fork):
+#   - openhands/server/config/server_config.py     (V0-tagged but the
+#                                                   settings/secret/user_auth
+#                                                   class fields are still active
+#                                                   and drive get_impl())
 FILES="
 openhands/app_server/sandbox/remote_sandbox_service.py
 openhands/app_server/app_conversation/app_conversation_service.py
@@ -59,6 +55,8 @@ openhands/app_server/event_callback/webhook_router.py
 openhands/app_server/services/db_session_injector.py
 openhands/app_server/config.py
 openhands/app_server/event_callback/sql_event_callback_service.py
+openhands/app_server/secrets/secrets_models.py
+openhands/server/config/server_config.py
 "
 
 FAILED=""

--- a/docker/download-fork-patches.sh
+++ b/docker/download-fork-patches.sh
@@ -18,7 +18,7 @@ FORK_REPO="${FORK_REPO:-zxkane/openhands}"
 #   - V1 custom modules COPY'd by Dockerfile (cognito_user_auth.py,
 #     s3_settings_store.py, s3_secrets_store.py — these don't go through this
 #     download because they live in openhands-infra/docker/, not upstream)
-FORK_REF="${FORK_REF:-4e480e79c47fb4c66c94c8176d130abdd6d5d2e9}"
+FORK_REF="${FORK_REF:-bb3fe51c920eec0b51bc7e118e340b582db0649f}"
 BASE_URL="https://raw.githubusercontent.com/${FORK_REPO}/${FORK_REF}"
 
 # Files modified in the v1.7.0 fork branch (verified via GitHub compare API:

--- a/docker/patch-fix.js
+++ b/docker/patch-fix.js
@@ -248,45 +248,17 @@
     } catch (e) {}
 
     if (!isCreateConversation || alreadyRetried) {
-      return origFetch.call(this, newUrl, opts).then(function(resp) {
-        // Detect auth redirect: iOS Safari ITP silently blocks SameSite=None cookies,
-        // causing API calls to return HTML (Cognito login page) instead of JSON.
-        //
-        // v1.7.0 NOTE: We can't rely on "200 + text/html + same-origin" alone — the
-        // V0 SPAStaticFiles fallback returns index.html (HTML) for any unrecognized
-        // path under /api/, and v1.7 frontend may legitimately request a route that
-        // upstream renamed/removed. To avoid the false-positive logout loop we
-        // observed in PR #81 staging E2E, we additionally inspect the response body
-        // for an unambiguous Cognito sign-in marker before triggering /_logout.
-        if (resp.ok && typeof newUrl === "string" && newUrl.indexOf('/api/') !== -1) {
-          var respUrl = resp.url || '';
-          var sameOrigin = respUrl.indexOf(window.location.origin) === 0 || respUrl === '';
-          if (sameOrigin) {
-            var ct = resp.headers.get('content-type') || '';
-            if (ct.indexOf('text/html') !== -1 && ct.indexOf('application/json') === -1) {
-              // Clone so we can inspect the body without consuming the original.
-              return resp.clone().text().then(function(bodyText) {
-                // Cognito hosted UI HTML always contains <title>Sign-in</title>.
-                // The OpenHands SPA index.html contains <title>OpenHands</title>.
-                var isCognitoLoginPage = bodyText.indexOf('<title>Sign-in</title>') !== -1;
-                if (isCognitoLoginPage) {
-                  console.warn('[Auth redirect] API returned Cognito sign-in page, redirecting to /_logout:', newUrl);
-                  window.location.href = '/_logout';
-                  return new Response(JSON.stringify({ error: 'auth_redirect', message: 'Session expired' }), {
-                    status: 401,
-                    headers: { 'Content-Type': 'application/json' }
-                  });
-                }
-                // Legitimate SPA fallback (index.html for an unknown /api/ path).
-                // Pass through unchanged — the caller's JSON parser will fail and
-                // surface as a normal application error, not an auth loop.
-                return resp;
-              });
-            }
-          }
-        }
-        return resp;
-      });
+      // The previous auth-redirect detector (logout-on-html) caused a redirect
+      // loop on v1.7.0: the V0 SPAStaticFiles fallback serves index.html for any
+      // unknown /api/ path, and v1.7 frontend requests several paths that don't
+      // exist server-side (renamed in V0 -> V1 cleanup). Hitting any one of
+      // those triggered an automatic /_logout, killing the freshly-set Cognito
+      // session and leaving the user stuck on the login page.
+      //
+      // Removed the auto-logout. If the session is genuinely expired, the
+      // caller's JSON parser will throw and the app's existing 401 handlers
+      // will surface a normal auth error — without nuking a valid session.
+      return origFetch.call(this, newUrl, opts);
     }
 
     return origFetch.call(this, newUrl, opts).then(function(resp) {

--- a/docker/patch-fix.js
+++ b/docker/patch-fix.js
@@ -627,45 +627,62 @@
   function ensureDefaultSettings() {
     if (ensurePromise) return ensurePromise;
 
-    ensurePromise = fetch('/api/options/models')
-      .then(function(r) { return r.json(); })
-      .then(function(models) {
-        var hasModels = Array.isArray(models) ? models.length > 0 : false;
-        if (!hasModels) return false;
+    // v1.7.0: model list moved from /api/options/models -> /api/v1/config/models/search
+    // and settings moved from /api/settings -> /api/v1/settings.
+    // V1 settings POST takes a partial dict; LLM fields nest under agent_settings_diff.
+    ensurePromise = fetch('/api/v1/config/models/search?limit=200', {credentials: 'include'})
+      .then(function(r) { return r.ok ? r.json() : null; })
+      .then(function(modelsPage) {
+        // V1 returns { items: [{provider, name, verified}, ...], next_page_id }.
+        // Older callers downstream still expect a flat array of model identifiers
+        // shaped like "<provider>/<name>", so we project for compatibility.
+        var modelList = [];
+        if (modelsPage && Array.isArray(modelsPage.items)) {
+          modelList = modelsPage.items.map(function(m) {
+            if (m && typeof m.name === 'string') {
+              return m.provider ? m.provider + '/' + m.name : m.name;
+            }
+            return null;
+          }).filter(Boolean);
+        }
+        if (modelList.length === 0) return false;
 
-        return fetch('/api/settings').then(function(settingsResp) {
+        return fetch('/api/v1/settings', {credentials: 'include'}).then(function(settingsResp) {
           if (settingsResp.ok) return true;
-          return isSettingsMissingResponse(settingsResp.clone ? settingsResp.clone() : settingsResp).then(function(missing) {
-            if (!missing) return false;
+          // V1 returns 404 + {"error":"Settings not found"} when the user has no settings yet.
+          if (settingsResp.status !== 404) return false;
 
-            console.log("Settings not found, creating default settings...");
-            var defaultModel = pickDefaultModel(models);
-            var bedrockModel = "bedrock/" + defaultModel;
-            console.log("Using Bedrock model:", bedrockModel);
+          console.log("Settings not found (V1), creating default settings...");
+          var defaultModel = pickDefaultModel(modelList);
+          var bedrockModel = "bedrock/" + defaultModel;
+          console.log("Using Bedrock model:", bedrockModel);
 
-            var defaultSettings = {
+          // V1 settings POST: nest LLM fields under agent_settings_diff.
+          var defaultSettings = {
+            agent_settings_diff: {
               llm_provider: "bedrock",
               llm_model: bedrockModel,
               llm_api_key: null,
               aws_region: null
-            };
+            }
+          };
 
-            return fetch('/api/settings', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify(defaultSettings)
-            }).then(function(createResp) {
-              if (createResp.ok) {
-                console.log("Default settings created successfully");
-                return true;
-              }
-              return parseJsonSafe(createResp).then(function(body) {
-                console.warn("Failed to create settings:", createResp.status, body);
-                return false;
-              }).catch(function() {
-                console.warn("Failed to create settings:", createResp.status);
-                return false;
-              });
+          return fetch('/api/v1/settings', {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(defaultSettings)
+          }).then(function(createResp) {
+            if (createResp.ok) {
+              console.log("Default settings created successfully (V1)");
+              return true;
+            }
+            return parseJsonSafe(createResp).then(function(body) {
+              console.warn("Failed to create V1 settings:", createResp.status, body);
+              return false;
+            }).catch(function() {
+              console.warn("Failed to create V1 settings:", createResp.status);
+              return false;
             });
           });
         });

--- a/docker/patch-fix.js
+++ b/docker/patch-fix.js
@@ -630,7 +630,8 @@
     // v1.7.0: model list moved from /api/options/models -> /api/v1/config/models/search
     // and settings moved from /api/settings -> /api/v1/settings.
     // V1 settings POST takes a partial dict; LLM fields nest under agent_settings_diff.
-    ensurePromise = fetch('/api/v1/config/models/search?limit=200', {credentials: 'include'})
+    // V1 enforces limit <= 100 on the models search endpoint.
+    ensurePromise = fetch('/api/v1/config/models/search?limit=100', {credentials: 'include'})
       .then(function(r) { return r.ok ? r.json() : null; })
       .then(function(modelsPage) {
         // V1 returns { items: [{provider, name, verified}, ...], next_page_id }.
@@ -657,13 +658,20 @@
           var bedrockModel = "bedrock/" + defaultModel;
           console.log("Using Bedrock model:", bedrockModel);
 
-          // V1 settings POST: nest LLM fields under agent_settings_diff.
+          // V1 settings POST: agent_settings_diff uses the nested SDK schema
+          // (matches model_dump shape — `llm` is a sub-object, NOT flat
+          // `llm_provider` / `llm_model` like V0). Sending flat keys is
+          // silently dropped during Pydantic merge and the model falls back
+          // to the default ("claude-sonnet-4-20250514"), which agent then
+          // tries to call as a direct Anthropic API and fails with
+          // "Missing Anthropic API Key".
           var defaultSettings = {
             agent_settings_diff: {
-              llm_provider: "bedrock",
-              llm_model: bedrockModel,
-              llm_api_key: null,
-              aws_region: null
+              llm: {
+                model: bedrockModel,
+                api_key: null,
+                aws_region_name: null
+              }
             }
           };
 

--- a/docker/patch-fix.js
+++ b/docker/patch-fix.js
@@ -251,19 +251,36 @@
       return origFetch.call(this, newUrl, opts).then(function(resp) {
         // Detect auth redirect: iOS Safari ITP silently blocks SameSite=None cookies,
         // causing API calls to return HTML (Cognito login page) instead of JSON.
-        // Only check responses that: (1) are from our domain's /api/ path, (2) returned
-        // 200 OK, and (3) weren't redirected to a different origin (resp.url check).
+        //
+        // v1.7.0 NOTE: We can't rely on "200 + text/html + same-origin" alone — the
+        // V0 SPAStaticFiles fallback returns index.html (HTML) for any unrecognized
+        // path under /api/, and v1.7 frontend may legitimately request a route that
+        // upstream renamed/removed. To avoid the false-positive logout loop we
+        // observed in PR #81 staging E2E, we additionally inspect the response body
+        // for an unambiguous Cognito sign-in marker before triggering /_logout.
         if (resp.ok && typeof newUrl === "string" && newUrl.indexOf('/api/') !== -1) {
           var respUrl = resp.url || '';
           var sameOrigin = respUrl.indexOf(window.location.origin) === 0 || respUrl === '';
           if (sameOrigin) {
             var ct = resp.headers.get('content-type') || '';
             if (ct.indexOf('text/html') !== -1 && ct.indexOf('application/json') === -1) {
-              console.warn('[Auth redirect] API returned HTML instead of JSON, redirecting to login:', newUrl);
-              window.location.href = '/_logout';
-              return new Response(JSON.stringify({ error: 'auth_redirect', message: 'Session expired' }), {
-                status: 401,
-                headers: { 'Content-Type': 'application/json' }
+              // Clone so we can inspect the body without consuming the original.
+              return resp.clone().text().then(function(bodyText) {
+                // Cognito hosted UI HTML always contains <title>Sign-in</title>.
+                // The OpenHands SPA index.html contains <title>OpenHands</title>.
+                var isCognitoLoginPage = bodyText.indexOf('<title>Sign-in</title>') !== -1;
+                if (isCognitoLoginPage) {
+                  console.warn('[Auth redirect] API returned Cognito sign-in page, redirecting to /_logout:', newUrl);
+                  window.location.href = '/_logout';
+                  return new Response(JSON.stringify({ error: 'auth_redirect', message: 'Session expired' }), {
+                    status: 401,
+                    headers: { 'Content-Type': 'application/json' }
+                  });
+                }
+                // Legitimate SPA fallback (index.html for an unknown /api/ path).
+                // Pass through unchanged — the caller's JSON parser will fail and
+                // surface as a normal application error, not an auth loop.
+                return resp;
               });
             }
           }

--- a/docker/s3_secrets_store.py
+++ b/docker/s3_secrets_store.py
@@ -1,55 +1,48 @@
 """
-User-scoped secrets storage for multi-tenancy.
+User-scoped secrets storage for multi-tenancy (V1 OpenHands).
 
 This module provides a SecretsStore implementation that stores secrets
 under user-specific paths in S3: users/{user_id}/secrets.json
 
-This enables per-user secrets isolation when using Cognito authentication.
-Without this, all users would share a global secrets.json file at the bucket root,
-which is a CRITICAL SECURITY VULNERABILITY.
+Without this, all users would share a global secrets.json file at the
+bucket root, which is a CRITICAL SECURITY VULNERABILITY.
 
 Path Format:
 - Authenticated users: users/{user_id}/secrets.json
 - Anonymous users: NOT SUPPORTED (raises ValueError)
 
-Design Decisions:
-- No anonymous users: System requires login, all users must have user_id
-- No global secrets file: User secrets stored only in user-scoped paths
-- Secrets structure follows OpenHands Secrets Pydantic model
+V1 NOTES (PR #81 / OpenHands v1.7.0):
+- Imports moved from openhands.storage.* to openhands.app_server.* —
+  upstream deleted the V0 storage subpackages in 1.7.0.
+- get_file_store no longer accepts file_store_web_hook_* args.
+- Secrets model moved to openhands.app_server.secrets.secrets_models.
+- The V0 helper methods (get_secret / set_secret / delete_secret /
+  list_secrets) are dropped — they were not part of the SecretsStore
+  ABC and had no callers in the upstream V1 codebase.
 """
 
 import json
 import logging
 from dataclasses import dataclass
 
+from openhands.app_server.file_store import get_file_store
+from openhands.app_server.file_store.files import FileStore
+from openhands.app_server.secrets.secrets_models import Secrets
+from openhands.app_server.secrets.secrets_store import SecretsStore
+from openhands.app_server.utils.async_utils import call_sync_from_async
 from openhands.core.config.openhands_config import OpenHandsConfig
-from openhands.storage import get_file_store
-from openhands.storage.data_models.secrets import Secrets
-from openhands.storage.files import FileStore
-from openhands.storage.secrets.secrets_store import SecretsStore
-from openhands.utils.async_utils import call_sync_from_async
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
-class S3SecretsStore(SecretsStore):
+class CognitoS3SecretsStore(SecretsStore):
     """Secrets store with user-scoped paths for multi-tenancy.
 
     When a user_id is provided, secrets are stored under:
         users/{user_id}/secrets.json
 
     Anonymous users are NOT supported - this store requires authentication.
-
-    Secrets Format (OpenHands standard):
-    {
-        "custom_secrets": {
-            "SECRET_NAME": {
-                "secret": "secret_value",
-                "description": "optional description"
-            }
-        }
-    }
 
     Attributes:
         file_store: The underlying file store (S3, local, etc.)
@@ -60,174 +53,56 @@ class S3SecretsStore(SecretsStore):
     user_id: str
 
     def _get_path(self) -> str:
-        """Get the user-specific secrets path.
-
-        Returns:
-            Path in format: users/{user_id}/secrets.json
-        """
         return f'users/{self.user_id}/secrets.json'
 
     async def load(self) -> Secrets | None:
-        """Load secrets from the user-specific path.
-
-        Returns:
-            Secrets object if found, None if not found.
-        """
         path = self._get_path()
-        logger.debug(f"S3SecretsStore.load: Loading secrets from {path}")
         try:
             json_str = await call_sync_from_async(self.file_store.read, path)
             data = json.loads(json_str)
-            # Create Secrets model from the loaded data
+            # Mirror upstream FileSecretsStore: filter out provider_tokens
+            # entries with no token (left behind after rotation/revoke).
+            provider_tokens = {
+                k: v
+                for k, v in (data.get('provider_tokens') or {}).items()
+                if v.get('token')
+            }
+            data['provider_tokens'] = provider_tokens
             secrets = Secrets(**data)
-            logger.info(f"S3SecretsStore: Loaded secrets for user {self.user_id}")
+            logger.info(f"CognitoS3SecretsStore: Loaded secrets for user {self.user_id}")
             return secrets
         except FileNotFoundError:
-            logger.debug(f"S3SecretsStore: No secrets found at {path}")
             return None
         except json.JSONDecodeError as e:
-            logger.warning(f"S3SecretsStore: Invalid JSON in secrets file {path}: {e}")
+            logger.warning(f"CognitoS3SecretsStore: Invalid JSON in {path}: {e}")
             return None
         except Exception as e:
-            logger.warning(f"S3SecretsStore: Failed to load secrets from {path}: {e}")
+            logger.warning(f"CognitoS3SecretsStore: Failed to load {path}: {e}")
             return None
 
     async def store(self, secrets: Secrets) -> None:
-        """Store secrets to the user-specific path.
-
-        Args:
-            secrets: Secrets Pydantic model to store.
-        """
         path = self._get_path()
-        logger.debug(f"S3SecretsStore.store: Storing secrets to {path}")
         try:
-            # Use Pydantic's model_dump_json with expose_secrets context
             json_str = secrets.model_dump_json(context={'expose_secrets': True})
             await call_sync_from_async(self.file_store.write, path, json_str)
-            logger.info(f"S3SecretsStore: Stored secrets for user {self.user_id}")
+            logger.info(f"CognitoS3SecretsStore: Stored secrets for user {self.user_id}")
         except Exception as e:
-            logger.error(f"S3SecretsStore: Failed to store secrets to {path}: {e}")
+            logger.error(f"CognitoS3SecretsStore: Failed to store {path}: {e}")
             raise
-
-    async def get_secret(self, name: str) -> str | None:
-        """Get a specific secret by name.
-
-        Args:
-            name: The name of the secret.
-
-        Returns:
-            The secret value if found, None otherwise.
-        """
-        secrets = await self.load()
-        if secrets is None:
-            return None
-
-        custom_secret = secrets.custom_secrets.get(name)
-        if custom_secret is None:
-            return None
-
-        return custom_secret.secret.get_secret_value()
-
-    async def set_secret(self, name: str, value: str, description: str | None = None) -> None:
-        """Set a specific secret.
-
-        Args:
-            name: The name of the secret.
-            value: The secret value.
-            description: Optional description of the secret.
-        """
-        secrets = await self.load()
-
-        # Get current custom_secrets as dict
-        current_secrets = {}
-        if secrets is not None:
-            # Export current secrets to dict
-            for secret_name, secret_value in secrets.custom_secrets.items():
-                current_secrets[secret_name] = {
-                    'secret': secret_value.secret.get_secret_value(),
-                    'description': secret_value.description,
-                }
-
-        # Add/update the new secret
-        secret_entry = {'secret': value, 'description': description or ''}
-        current_secrets[name] = secret_entry
-
-        # Create new Secrets model
-        new_secrets = Secrets(custom_secrets=current_secrets)
-        await self.store(new_secrets)
-
-    async def delete_secret(self, name: str) -> bool:
-        """Delete a specific secret.
-
-        Args:
-            name: The name of the secret to delete.
-
-        Returns:
-            True if the secret was deleted, False if it didn't exist.
-        """
-        secrets = await self.load()
-        if secrets is None:
-            return False
-
-        if name not in secrets.custom_secrets:
-            return False
-
-        # Get current custom_secrets as dict, excluding the one to delete
-        current_secrets = {}
-        for secret_name, secret_value in secrets.custom_secrets.items():
-            if secret_name != name:
-                current_secrets[secret_name] = {
-                    'secret': secret_value.secret.get_secret_value(),
-                    'description': secret_value.description,
-                }
-
-        # Create new Secrets model without the deleted secret
-        new_secrets = Secrets(custom_secrets=current_secrets)
-        await self.store(new_secrets)
-        return True
-
-    async def list_secrets(self) -> list[str]:
-        """List all secret names.
-
-        Returns:
-            List of secret names (values are not exposed).
-        """
-        secrets = await self.load()
-        if secrets is None:
-            return []
-
-        return list(secrets.custom_secrets.keys())
 
     @classmethod
     async def get_instance(
         cls, config: OpenHandsConfig, user_id: str | None
-    ) -> 'S3SecretsStore':
-        """Create a secrets store instance for the given user.
-
-        Args:
-            config: OpenHands configuration.
-            user_id: The authenticated user's ID (Cognito sub).
-
-        Returns:
-            An S3SecretsStore instance configured for the user.
-
-        Raises:
-            ValueError: If user_id is None or empty (anonymous users not supported).
-        """
+    ) -> 'CognitoS3SecretsStore':
         if not user_id:
             raise ValueError(
                 'user_id is required for multi-tenant secrets. '
                 'Anonymous users are not supported in this deployment.'
             )
 
-        logger.info(f"S3SecretsStore.get_instance: Creating store for user {user_id}")
-
         file_store = get_file_store(
             file_store_type=config.file_store,
             file_store_path=config.file_store_path,
-            file_store_web_hook_url=config.file_store_web_hook_url,
-            file_store_web_hook_headers=config.file_store_web_hook_headers,
-            file_store_web_hook_batch=config.file_store_web_hook_batch,
         )
 
         return cls(file_store=file_store, user_id=user_id)

--- a/docker/s3_settings_store.py
+++ b/docker/s3_settings_store.py
@@ -1,39 +1,41 @@
 """
-User-scoped settings storage for multi-tenancy.
+User-scoped settings storage for multi-tenancy (V1 OpenHands).
 
 This module provides a SettingsStore implementation that stores settings
 under user-specific paths in S3: users/{user_id}/settings.json
 
 This enables per-user settings isolation when using Cognito authentication.
-Without this, all users would share a global settings.json file at the bucket root,
-which is a critical security vulnerability.
+Without this, all users would share a global settings.json file at the
+bucket root, which is a critical security vulnerability.
 
 Path Format:
 - Authenticated users: users/{user_id}/settings.json
 - Anonymous users: NOT SUPPORTED (raises ValueError)
 
-Design Decisions:
-- No anonymous users: System requires login, all users must have user_id
-- No global settings file: User settings stored only in user-scoped paths
-- Global config: Provided via config.toml (LLM model, etc.), not settings.json
+V1 NOTES (PR #81 / OpenHands v1.7.0):
+- Imports moved from openhands.storage.* to openhands.app_server.* —
+  upstream deleted the V0 storage subpackages in 1.7.0.
+- get_file_store no longer accepts file_store_web_hook_* args; webhook
+  support was removed alongside the V0 collapse.
+- Settings model moved to openhands.app_server.settings.settings_models.
 """
 
 import json
 import logging
 from dataclasses import dataclass
 
+from openhands.app_server.file_store import get_file_store
+from openhands.app_server.file_store.files import FileStore
+from openhands.app_server.settings.settings_models import Settings
+from openhands.app_server.settings.settings_store import SettingsStore
+from openhands.app_server.utils.async_utils import call_sync_from_async
 from openhands.core.config.openhands_config import OpenHandsConfig
-from openhands.storage import get_file_store
-from openhands.storage.data_models.settings import Settings
-from openhands.storage.files import FileStore
-from openhands.storage.settings.settings_store import SettingsStore
-from openhands.utils.async_utils import call_sync_from_async
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
-class S3SettingsStore(SettingsStore):
+class CognitoS3SettingsStore(SettingsStore):
     """Settings store with user-scoped paths for multi-tenancy.
 
     When a user_id is provided, settings are stored under:
@@ -50,85 +52,53 @@ class S3SettingsStore(SettingsStore):
     user_id: str
 
     def _get_path(self) -> str:
-        """Get the user-specific settings path.
-
-        Returns:
-            Path in format: users/{user_id}/settings.json
-        """
         return f'users/{self.user_id}/settings.json'
 
     async def load(self) -> Settings | None:
-        """Load settings from the user-specific path.
-
-        Returns:
-            Settings object if found, None if not found.
-        """
         path = self._get_path()
-        logger.debug(f"S3SettingsStore.load: Loading settings from {path}")
         try:
             json_str = await call_sync_from_async(self.file_store.read, path)
             kwargs = json.loads(json_str)
             settings = Settings(**kwargs)
-            # Ensure v1 is enabled (required for V1 app server)
+            # Ensure v1 is enabled — preserved from V0; harmless on v1.7.0
+            # but defensive against settings files written by v1.6.0.
             settings.v1_enabled = True
-            logger.info(f"S3SettingsStore: Loaded settings for user {self.user_id}")
+            logger.info(f"CognitoS3SettingsStore: Loaded settings for user {self.user_id}")
             return settings
         except FileNotFoundError:
-            logger.debug(f"S3SettingsStore: No settings found at {path}")
             return None
         except json.JSONDecodeError as e:
-            logger.warning(f"S3SettingsStore: Invalid JSON in settings file {path}: {e}")
+            logger.warning(f"CognitoS3SettingsStore: Invalid JSON in {path}: {e}")
             return None
         except Exception as e:
-            logger.warning(f"S3SettingsStore: Failed to load settings from {path}: {e}")
+            logger.warning(f"CognitoS3SettingsStore: Failed to load {path}: {e}")
             return None
 
     async def store(self, settings: Settings) -> None:
-        """Store settings to the user-specific path.
-
-        Args:
-            settings: The Settings object to store.
-        """
         path = self._get_path()
-        logger.debug(f"S3SettingsStore.store: Storing settings to {path}")
         try:
-            json_str = settings.model_dump_json(context={'expose_secrets': True})
+            json_str = settings.model_dump_json(
+                context={'expose_secrets': True, 'persist_settings': True}
+            )
             await call_sync_from_async(self.file_store.write, path, json_str)
-            logger.info(f"S3SettingsStore: Stored settings for user {self.user_id}")
+            logger.info(f"CognitoS3SettingsStore: Stored settings for user {self.user_id}")
         except Exception as e:
-            logger.error(f"S3SettingsStore: Failed to store settings to {path}: {e}")
+            logger.error(f"CognitoS3SettingsStore: Failed to store {path}: {e}")
             raise
 
     @classmethod
     async def get_instance(
         cls, config: OpenHandsConfig, user_id: str | None
-    ) -> 'S3SettingsStore':
-        """Create a settings store instance for the given user.
-
-        Args:
-            config: OpenHands configuration.
-            user_id: The authenticated user's ID (Cognito sub).
-
-        Returns:
-            An S3SettingsStore instance configured for the user.
-
-        Raises:
-            ValueError: If user_id is None or empty (anonymous users not supported).
-        """
+    ) -> 'CognitoS3SettingsStore':
         if not user_id:
             raise ValueError(
                 'user_id is required for multi-tenant settings. '
                 'Anonymous users are not supported in this deployment.'
             )
 
-        logger.info(f"S3SettingsStore.get_instance: Creating store for user {user_id}")
-
         file_store = get_file_store(
             file_store_type=config.file_store,
             file_store_path=config.file_store_path,
-            file_store_web_hook_url=config.file_store_web_hook_url,
-            file_store_web_hook_headers=config.file_store_web_hook_headers,
-            file_store_web_hook_batch=config.file_store_web_hook_batch,
         )
 
         return cls(file_store=file_store, user_id=user_id)

--- a/docker/test_cognito_user_auth.py
+++ b/docker/test_cognito_user_auth.py
@@ -28,14 +28,21 @@ class MockDefaultUserAuth(MockUserAuth):
     pass
 
 
-# Set up mock modules before importing
+# Set up mock modules before importing.
+# v1.7.0 moved UserAuth / DefaultUserAuth from openhands.server.user_auth to
+# openhands.app_server.user_auth (still tagged Legacy-V0 but actively wired
+# from V1's AuthUserContext).
 sys.modules['openhands'] = MagicMock()
-sys.modules['openhands.server'] = MagicMock()
-sys.modules['openhands.server.user_auth'] = MagicMock()
-sys.modules['openhands.server.user_auth.user_auth'] = MagicMock()
-sys.modules['openhands.server.user_auth.user_auth'].UserAuth = MockUserAuth
-sys.modules['openhands.server.user_auth.default_user_auth'] = MagicMock()
-sys.modules['openhands.server.user_auth.default_user_auth'].DefaultUserAuth = MockDefaultUserAuth
+sys.modules['openhands.app_server'] = MagicMock()
+sys.modules['openhands.app_server.user_auth'] = MagicMock()
+sys.modules['openhands.app_server.user_auth.user_auth'] = MagicMock()
+sys.modules['openhands.app_server.user_auth.user_auth'].UserAuth = MockUserAuth
+sys.modules['openhands.app_server.user_auth.default_user_auth'] = MagicMock()
+sys.modules['openhands.app_server.user_auth.default_user_auth'].DefaultUserAuth = MockDefaultUserAuth
+# settings_models is imported lazily inside get_user_settings, but mocking it
+# here keeps imports stable if the module under test ever moves the import up.
+sys.modules['openhands.app_server.settings'] = MagicMock()
+sys.modules['openhands.app_server.settings.settings_models'] = MagicMock()
 
 # Also mock fastapi Request
 mock_request_module = MagicMock()

--- a/docker/test_cognito_user_auth.py
+++ b/docker/test_cognito_user_auth.py
@@ -340,5 +340,74 @@ class TestUserConfigEnabled:
                 del os.environ['USER_CONFIG_ENABLED']
 
 
+class TestLoadGlobalMcpServers:
+    """Tests for _load_global_mcp_servers() — config.toml [mcp] parser."""
+
+    def test_returns_empty_when_file_missing(self, tmp_path, monkeypatch):
+        missing = tmp_path / 'nope.toml'
+        monkeypatch.setattr('cognito_user_auth.GLOBAL_CONFIG_TOML_PATH', missing)
+        from cognito_user_auth import _load_global_mcp_servers
+        assert _load_global_mcp_servers() == {}
+
+    def test_returns_empty_when_no_mcp_section(self, tmp_path, monkeypatch):
+        toml_path = tmp_path / 'config.toml'
+        toml_path.write_text('[core]\nworkspace_base = "/x"\n')
+        monkeypatch.setattr('cognito_user_auth.GLOBAL_CONFIG_TOML_PATH', toml_path)
+        from cognito_user_auth import _load_global_mcp_servers
+        assert _load_global_mcp_servers() == {}
+
+    def test_parses_shttp_servers_into_fastmcp_shape(self, tmp_path, monkeypatch):
+        toml_path = tmp_path / 'config.toml'
+        toml_path.write_text(
+            '[mcp]\n'
+            'shttp_servers = [\n'
+            '    { url = "https://knowledge-mcp.global.api.aws" },\n'
+            ']\n'
+        )
+        monkeypatch.setattr('cognito_user_auth.GLOBAL_CONFIG_TOML_PATH', toml_path)
+        from cognito_user_auth import _load_global_mcp_servers
+        servers = _load_global_mcp_servers()
+        # Name derived from host's first label since no name given
+        assert servers == {'knowledge-mcp': {'url': 'https://knowledge-mcp.global.api.aws'}}
+
+    def test_parses_stdio_servers_with_args_and_env(self, tmp_path, monkeypatch):
+        toml_path = tmp_path / 'config.toml'
+        toml_path.write_text(
+            '[mcp]\n'
+            'stdio_servers = [\n'
+            '    { name = "chrome-devtools", command = "npx", args = ["-y", "chrome-devtools-mcp@latest"], env = { FOO = "bar" } },\n'
+            ']\n'
+        )
+        monkeypatch.setattr('cognito_user_auth.GLOBAL_CONFIG_TOML_PATH', toml_path)
+        from cognito_user_auth import _load_global_mcp_servers
+        servers = _load_global_mcp_servers()
+        assert servers == {
+            'chrome-devtools': {
+                'command': 'npx',
+                'args': ['-y', 'chrome-devtools-mcp@latest'],
+                'env': {'FOO': 'bar'},
+            }
+        }
+
+    def test_skips_invalid_entries(self, tmp_path, monkeypatch):
+        toml_path = tmp_path / 'config.toml'
+        toml_path.write_text(
+            '[mcp]\n'
+            'shttp_servers = [{ name = "bad" }]\n'  # missing url
+            'stdio_servers = [{ command = "x" }]\n'  # missing name
+        )
+        monkeypatch.setattr('cognito_user_auth.GLOBAL_CONFIG_TOML_PATH', toml_path)
+        from cognito_user_auth import _load_global_mcp_servers
+        assert _load_global_mcp_servers() == {}
+
+    def test_returns_empty_on_malformed_toml(self, tmp_path, monkeypatch):
+        toml_path = tmp_path / 'config.toml'
+        toml_path.write_text('not valid toml = = =')
+        monkeypatch.setattr('cognito_user_auth.GLOBAL_CONFIG_TOML_PATH', toml_path)
+        from cognito_user_auth import _load_global_mcp_servers
+        # Best-effort parsing — must not raise even on broken files
+        assert _load_global_mcp_servers() == {}
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/docker/test_s3_stores.py
+++ b/docker/test_s3_stores.py
@@ -1,5 +1,5 @@
 """
-Unit tests for S3SettingsStore and S3SecretsStore.
+Unit tests for CognitoS3SettingsStore and CognitoS3SecretsStore.
 
 These tests verify the user-scoped storage functionality including:
 - User-specific path generation (users/{user_id}/settings.json, users/{user_id}/secrets.json)
@@ -19,15 +19,14 @@ import sys
 from dataclasses import dataclass
 
 
-# Mock OpenHands modules before importing the modules under test
+# Mock OpenHands modules before importing the modules under test.
+# v1.7.0 dropped the file_store_web_hook_* fields from OpenHandsConfig (and the
+# matching kwargs from get_file_store), so they're not part of the mock.
 @dataclass
 class MockOpenHandsConfig:
     """Mock OpenHands configuration."""
     file_store: str = 's3'
     file_store_path: str = 'test-bucket'
-    file_store_web_hook_url: str | None = None
-    file_store_web_hook_headers: dict | None = None
-    file_store_web_hook_batch: int = 0
 
 
 @dataclass
@@ -90,25 +89,28 @@ class MockSecrets:
         return json.dumps(result)
 
 
-# Set up mock modules
+# Set up mock modules.
+# v1.7.0 collapsed the V0 openhands.storage.* and openhands.utils.* surfaces
+# into openhands.app_server.{settings,secrets,file_store,utils}.* — mocks
+# follow.
 sys.modules['openhands'] = MagicMock()
 sys.modules['openhands.core'] = MagicMock()
 sys.modules['openhands.core.config'] = MagicMock()
 sys.modules['openhands.core.config.openhands_config'] = MagicMock()
 sys.modules['openhands.core.config.openhands_config'].OpenHandsConfig = MockOpenHandsConfig
-sys.modules['openhands.storage'] = MagicMock()
-sys.modules['openhands.storage.files'] = MagicMock()
-sys.modules['openhands.storage.data_models'] = MagicMock()
-sys.modules['openhands.storage.data_models.settings'] = MagicMock()
-sys.modules['openhands.storage.data_models.settings'].Settings = MockSettings
-sys.modules['openhands.storage.data_models.secrets'] = MagicMock()
-sys.modules['openhands.storage.data_models.secrets'].Secrets = MockSecrets
-sys.modules['openhands.storage.settings'] = MagicMock()
-sys.modules['openhands.storage.settings.settings_store'] = MagicMock()
-sys.modules['openhands.storage.secrets'] = MagicMock()
-sys.modules['openhands.storage.secrets.secrets_store'] = MagicMock()
-sys.modules['openhands.utils'] = MagicMock()
-sys.modules['openhands.utils.async_utils'] = MagicMock()
+sys.modules['openhands.app_server'] = MagicMock()
+sys.modules['openhands.app_server.file_store'] = MagicMock()
+sys.modules['openhands.app_server.file_store.files'] = MagicMock()
+sys.modules['openhands.app_server.settings'] = MagicMock()
+sys.modules['openhands.app_server.settings.settings_models'] = MagicMock()
+sys.modules['openhands.app_server.settings.settings_models'].Settings = MockSettings
+sys.modules['openhands.app_server.settings.settings_store'] = MagicMock()
+sys.modules['openhands.app_server.secrets'] = MagicMock()
+sys.modules['openhands.app_server.secrets.secrets_models'] = MagicMock()
+sys.modules['openhands.app_server.secrets.secrets_models'].Secrets = MockSecrets
+sys.modules['openhands.app_server.secrets.secrets_store'] = MagicMock()
+sys.modules['openhands.app_server.utils'] = MagicMock()
+sys.modules['openhands.app_server.utils.async_utils'] = MagicMock()
 
 # Create mock base classes
 class MockSettingsStore:
@@ -121,34 +123,35 @@ class MockSecretsStore:
     pass
 
 
-sys.modules['openhands.storage.settings.settings_store'].SettingsStore = MockSettingsStore
-sys.modules['openhands.storage.secrets.secrets_store'].SecretsStore = MockSecretsStore
+sys.modules['openhands.app_server.settings.settings_store'].SettingsStore = MockSettingsStore
+sys.modules['openhands.app_server.secrets.secrets_store'].SecretsStore = MockSecretsStore
 
 
-# Now import the modules under test
-from s3_settings_store import S3SettingsStore
-from s3_secrets_store import S3SecretsStore
+# Now import the modules under test (renamed in v1.7.0:
+# CognitoS3SettingsStore -> CognitoS3SettingsStore, CognitoS3SecretsStore -> CognitoS3SecretsStore)
+from s3_settings_store import CognitoS3SettingsStore
+from s3_secrets_store import CognitoS3SecretsStore
 
 
-class TestS3SettingsStorePathGeneration:
-    """Tests for S3SettingsStore path generation."""
+class TestCognitoS3SettingsStorePathGeneration:
+    """Tests for CognitoS3SettingsStore path generation."""
 
     def test_get_path_returns_user_scoped_path(self):
         """Should return users/{user_id}/settings.json."""
-        store = S3SettingsStore(file_store=MagicMock(), user_id="user-123")
+        store = CognitoS3SettingsStore(file_store=MagicMock(), user_id="user-123")
         assert store._get_path() == "users/user-123/settings.json"
 
     def test_different_users_have_different_paths(self):
         """Different user_ids should produce different paths."""
-        store_a = S3SettingsStore(file_store=MagicMock(), user_id="user-aaa")
-        store_b = S3SettingsStore(file_store=MagicMock(), user_id="user-bbb")
+        store_a = CognitoS3SettingsStore(file_store=MagicMock(), user_id="user-aaa")
+        store_b = CognitoS3SettingsStore(file_store=MagicMock(), user_id="user-bbb")
         assert store_a._get_path() != store_b._get_path()
         assert "user-aaa" in store_a._get_path()
         assert "user-bbb" in store_b._get_path()
 
     def test_path_format_matches_conversation_store_pattern(self):
         """Path should follow same pattern as CognitoFileConversationStore."""
-        store = S3SettingsStore(file_store=MagicMock(), user_id="cognito-sub-uuid")
+        store = CognitoS3SettingsStore(file_store=MagicMock(), user_id="cognito-sub-uuid")
         path = store._get_path()
         # Should be: users/{user_id}/settings.json
         assert path.startswith("users/")
@@ -158,27 +161,27 @@ class TestS3SettingsStorePathGeneration:
     def test_path_with_complex_user_id(self):
         """Should handle complex user IDs (UUID format from Cognito)."""
         user_id = "abc12345-def6-7890-ghij-klmnopqrstuv"
-        store = S3SettingsStore(file_store=MagicMock(), user_id=user_id)
+        store = CognitoS3SettingsStore(file_store=MagicMock(), user_id=user_id)
         path = store._get_path()
         assert path == f"users/{user_id}/settings.json"
 
 
-class TestS3SettingsStoreGetInstance:
-    """Tests for S3SettingsStore.get_instance class method."""
+class TestCognitoS3SettingsStoreGetInstance:
+    """Tests for CognitoS3SettingsStore.get_instance class method."""
 
     @pytest.mark.asyncio
     async def test_get_instance_requires_user_id(self):
         """Should raise ValueError when user_id is None."""
         mock_config = MockOpenHandsConfig()
         with pytest.raises(ValueError, match="user_id is required"):
-            await S3SettingsStore.get_instance(mock_config, None)
+            await CognitoS3SettingsStore.get_instance(mock_config, None)
 
     @pytest.mark.asyncio
     async def test_get_instance_requires_user_id_empty_string(self):
         """Should raise ValueError when user_id is empty string."""
         mock_config = MockOpenHandsConfig()
         with pytest.raises(ValueError, match="user_id is required"):
-            await S3SettingsStore.get_instance(mock_config, "")
+            await CognitoS3SettingsStore.get_instance(mock_config, "")
 
     @pytest.mark.asyncio
     @patch('s3_settings_store.get_file_store')
@@ -188,7 +191,7 @@ class TestS3SettingsStoreGetInstance:
         mock_get_file_store.return_value = mock_file_store
         mock_config = MockOpenHandsConfig()
 
-        store = await S3SettingsStore.get_instance(mock_config, "user-xyz")
+        store = await CognitoS3SettingsStore.get_instance(mock_config, "user-xyz")
 
         assert store.user_id == "user-xyz"
         assert store.file_store == mock_file_store
@@ -204,7 +207,7 @@ class TestS3SettingsStoreGetInstance:
             file_store_path='my-bucket'
         )
 
-        await S3SettingsStore.get_instance(mock_config, "user-xyz")
+        await CognitoS3SettingsStore.get_instance(mock_config, "user-xyz")
 
         mock_get_file_store.assert_called_once()
         call_kwargs = mock_get_file_store.call_args
@@ -212,8 +215,8 @@ class TestS3SettingsStoreGetInstance:
         assert call_kwargs[1]['file_store_path'] == 'my-bucket'
 
 
-class TestS3SettingsStoreLoad:
-    """Tests for S3SettingsStore.load method."""
+class TestCognitoS3SettingsStoreLoad:
+    """Tests for CognitoS3SettingsStore.load method."""
 
     @pytest.mark.asyncio
     @patch('s3_settings_store.call_sync_from_async', new_callable=AsyncMock)
@@ -223,7 +226,7 @@ class TestS3SettingsStoreLoad:
         settings_data = {"llm_model": "gpt-4", "language": "en", "v1_enabled": True}
         mock_call_sync.return_value = json.dumps(settings_data)
 
-        store = S3SettingsStore(file_store=mock_file_store, user_id="user-123")
+        store = CognitoS3SettingsStore(file_store=mock_file_store, user_id="user-123")
         result = await store.load()
 
         mock_call_sync.assert_called_once()
@@ -237,7 +240,7 @@ class TestS3SettingsStoreLoad:
         mock_file_store = MagicMock()
         mock_call_sync.side_effect = FileNotFoundError("Not found")
 
-        store = S3SettingsStore(file_store=mock_file_store, user_id="user-123")
+        store = CognitoS3SettingsStore(file_store=mock_file_store, user_id="user-123")
         result = await store.load()
 
         assert result is None
@@ -249,14 +252,14 @@ class TestS3SettingsStoreLoad:
         mock_file_store = MagicMock()
         mock_call_sync.return_value = "not valid json {"
 
-        store = S3SettingsStore(file_store=mock_file_store, user_id="user-123")
+        store = CognitoS3SettingsStore(file_store=mock_file_store, user_id="user-123")
         result = await store.load()
 
         assert result is None
 
 
-class TestS3SettingsStoreStore:
-    """Tests for S3SettingsStore.store method."""
+class TestCognitoS3SettingsStoreStore:
+    """Tests for CognitoS3SettingsStore.store method."""
 
     @pytest.mark.asyncio
     @patch('s3_settings_store.call_sync_from_async', new_callable=AsyncMock)
@@ -265,7 +268,7 @@ class TestS3SettingsStoreStore:
         mock_file_store = MagicMock()
         mock_settings = MockSettings()
 
-        store = S3SettingsStore(file_store=mock_file_store, user_id="user-456")
+        store = CognitoS3SettingsStore(file_store=mock_file_store, user_id="user-456")
         await store.store(mock_settings)
 
         mock_call_sync.assert_called_once()
@@ -273,45 +276,45 @@ class TestS3SettingsStoreStore:
         assert call_args[1] == "users/user-456/settings.json"
 
 
-class TestS3SecretsStorePathGeneration:
-    """Tests for S3SecretsStore path generation."""
+class TestCognitoS3SecretsStorePathGeneration:
+    """Tests for CognitoS3SecretsStore path generation."""
 
     def test_get_path_returns_user_scoped_path(self):
         """Should return users/{user_id}/secrets.json."""
-        store = S3SecretsStore(file_store=MagicMock(), user_id="user-789")
+        store = CognitoS3SecretsStore(file_store=MagicMock(), user_id="user-789")
         assert store._get_path() == "users/user-789/secrets.json"
 
     def test_different_users_have_different_paths(self):
         """Different user_ids should produce different paths."""
-        store_a = S3SecretsStore(file_store=MagicMock(), user_id="user-a")
-        store_b = S3SecretsStore(file_store=MagicMock(), user_id="user-b")
+        store_a = CognitoS3SecretsStore(file_store=MagicMock(), user_id="user-a")
+        store_b = CognitoS3SecretsStore(file_store=MagicMock(), user_id="user-b")
         assert store_a._get_path() != store_b._get_path()
 
     def test_path_format_is_consistent(self):
         """Path should follow consistent format."""
-        store = S3SecretsStore(file_store=MagicMock(), user_id="cognito-sub-uuid")
+        store = CognitoS3SecretsStore(file_store=MagicMock(), user_id="cognito-sub-uuid")
         path = store._get_path()
         assert path.startswith("users/")
         assert path.endswith("/secrets.json")
         assert "cognito-sub-uuid" in path
 
 
-class TestS3SecretsStoreGetInstance:
-    """Tests for S3SecretsStore.get_instance class method."""
+class TestCognitoS3SecretsStoreGetInstance:
+    """Tests for CognitoS3SecretsStore.get_instance class method."""
 
     @pytest.mark.asyncio
     async def test_get_instance_requires_user_id(self):
         """Should raise ValueError when user_id is None."""
         mock_config = MockOpenHandsConfig()
         with pytest.raises(ValueError, match="user_id is required"):
-            await S3SecretsStore.get_instance(mock_config, None)
+            await CognitoS3SecretsStore.get_instance(mock_config, None)
 
     @pytest.mark.asyncio
     async def test_get_instance_requires_user_id_empty_string(self):
         """Should raise ValueError when user_id is empty string."""
         mock_config = MockOpenHandsConfig()
         with pytest.raises(ValueError, match="user_id is required"):
-            await S3SecretsStore.get_instance(mock_config, "")
+            await CognitoS3SecretsStore.get_instance(mock_config, "")
 
     @pytest.mark.asyncio
     @patch('s3_secrets_store.get_file_store')
@@ -321,14 +324,14 @@ class TestS3SecretsStoreGetInstance:
         mock_get_file_store.return_value = mock_file_store
         mock_config = MockOpenHandsConfig()
 
-        store = await S3SecretsStore.get_instance(mock_config, "user-xyz")
+        store = await CognitoS3SecretsStore.get_instance(mock_config, "user-xyz")
 
         assert store.user_id == "user-xyz"
         assert store.file_store == mock_file_store
 
 
-class TestS3SecretsStoreLoad:
-    """Tests for S3SecretsStore.load method."""
+class TestCognitoS3SecretsStoreLoad:
+    """Tests for CognitoS3SecretsStore.load method."""
 
     @pytest.mark.asyncio
     @patch('s3_secrets_store.call_sync_from_async', new_callable=AsyncMock)
@@ -338,7 +341,7 @@ class TestS3SecretsStoreLoad:
         secrets_data = {"custom_secrets": {"api_key": {"secret": "xxx"}}}
         mock_call_sync.return_value = json.dumps(secrets_data)
 
-        store = S3SecretsStore(file_store=mock_file_store, user_id="user-123")
+        store = CognitoS3SecretsStore(file_store=mock_file_store, user_id="user-123")
         result = await store.load()
 
         mock_call_sync.assert_called_once()
@@ -352,7 +355,7 @@ class TestS3SecretsStoreLoad:
         mock_file_store = MagicMock()
         mock_call_sync.side_effect = FileNotFoundError("Not found")
 
-        store = S3SecretsStore(file_store=mock_file_store, user_id="user-123")
+        store = CognitoS3SecretsStore(file_store=mock_file_store, user_id="user-123")
         result = await store.load()
 
         assert result is None
@@ -364,14 +367,14 @@ class TestS3SecretsStoreLoad:
         mock_file_store = MagicMock()
         mock_call_sync.return_value = "invalid json"
 
-        store = S3SecretsStore(file_store=mock_file_store, user_id="user-123")
+        store = CognitoS3SecretsStore(file_store=mock_file_store, user_id="user-123")
         result = await store.load()
 
         assert result is None
 
 
-class TestS3SecretsStoreStore:
-    """Tests for S3SecretsStore.store method."""
+class TestCognitoS3SecretsStoreStore:
+    """Tests for CognitoS3SecretsStore.store method."""
 
     @pytest.mark.asyncio
     @patch('s3_secrets_store.call_sync_from_async', new_callable=AsyncMock)
@@ -381,7 +384,7 @@ class TestS3SecretsStoreStore:
         # Create a MockSecrets object instead of dict
         mock_secrets = MockSecrets(custom_secrets={"my_key": {"secret": "value", "description": ""}})
 
-        store = S3SecretsStore(file_store=mock_file_store, user_id="user-456")
+        store = CognitoS3SecretsStore(file_store=mock_file_store, user_id="user-456")
         await store.store(mock_secrets)
 
         mock_call_sync.assert_called_once()
@@ -389,68 +392,10 @@ class TestS3SecretsStoreStore:
         assert call_args[1] == "users/user-456/secrets.json"
 
 
-class TestS3SecretsStoreSecretOperations:
-    """Tests for S3SecretsStore secret operations (get, set, delete, list)."""
-
-    @pytest.mark.asyncio
-    @patch('s3_secrets_store.call_sync_from_async', new_callable=AsyncMock)
-    async def test_get_secret_returns_value(self, mock_call_sync):
-        """Should return secret value by name."""
-        mock_file_store = MagicMock()
-        secrets_data = {
-            "custom_secrets": {
-                "API_KEY": {"secret": "my-api-key", "description": "Test key"}
-            }
-        }
-        mock_call_sync.return_value = json.dumps(secrets_data)
-
-        store = S3SecretsStore(file_store=mock_file_store, user_id="user-123")
-        result = await store.get_secret("API_KEY")
-
-        assert result == "my-api-key"
-
-    @pytest.mark.asyncio
-    @patch('s3_secrets_store.call_sync_from_async', new_callable=AsyncMock)
-    async def test_get_secret_returns_none_if_not_found(self, mock_call_sync):
-        """Should return None when secret doesn't exist."""
-        mock_file_store = MagicMock()
-        secrets_data = {"custom_secrets": {}}
-        mock_call_sync.return_value = json.dumps(secrets_data)
-
-        store = S3SecretsStore(file_store=mock_file_store, user_id="user-123")
-        result = await store.get_secret("NONEXISTENT")
-
-        assert result is None
-
-    @pytest.mark.asyncio
-    @patch('s3_secrets_store.call_sync_from_async', new_callable=AsyncMock)
-    async def test_list_secrets_returns_names(self, mock_call_sync):
-        """Should return list of secret names."""
-        mock_file_store = MagicMock()
-        secrets_data = {
-            "custom_secrets": {
-                "KEY_A": {"secret": "a"},
-                "KEY_B": {"secret": "b"}
-            }
-        }
-        mock_call_sync.return_value = json.dumps(secrets_data)
-
-        store = S3SecretsStore(file_store=mock_file_store, user_id="user-123")
-        result = await store.list_secrets()
-
-        assert set(result) == {"KEY_A", "KEY_B"}
-
-    @pytest.mark.asyncio
-    @patch('s3_secrets_store.call_sync_from_async', new_callable=AsyncMock)
-    async def test_list_secrets_returns_empty_when_no_file(self, mock_call_sync):
-        """Should return empty list when no secrets file."""
-        mock_file_store = MagicMock()
-        mock_call_sync.side_effect = FileNotFoundError()
-
-        store = S3SecretsStore(file_store=mock_file_store, user_id="user-123")
-        result = await store.list_secrets()
-
-        assert result == []
+# V0 helper methods (get_secret / set_secret / delete_secret / list_secrets)
+# were dropped in v1.7.0 along with the V0 storage package collapse — they were
+# never part of the SecretsStore ABC and had no callers. Their tests went with
+# them. The load/store path coverage above is sufficient.
 
 
 class TestUserIsolation:
@@ -461,8 +406,8 @@ class TestUserIsolation:
         user_a_id = "user-a-cognito-sub"
         user_b_id = "user-b-cognito-sub"
 
-        store_a = S3SettingsStore(file_store=MagicMock(), user_id=user_a_id)
-        store_b = S3SettingsStore(file_store=MagicMock(), user_id=user_b_id)
+        store_a = CognitoS3SettingsStore(file_store=MagicMock(), user_id=user_a_id)
+        store_b = CognitoS3SettingsStore(file_store=MagicMock(), user_id=user_b_id)
 
         assert user_a_id in store_a._get_path()
         assert user_b_id not in store_a._get_path()
@@ -474,8 +419,8 @@ class TestUserIsolation:
         user_a_id = "user-a-cognito-sub"
         user_b_id = "user-b-cognito-sub"
 
-        store_a = S3SecretsStore(file_store=MagicMock(), user_id=user_a_id)
-        store_b = S3SecretsStore(file_store=MagicMock(), user_id=user_b_id)
+        store_a = CognitoS3SecretsStore(file_store=MagicMock(), user_id=user_a_id)
+        store_b = CognitoS3SecretsStore(file_store=MagicMock(), user_id=user_b_id)
 
         assert user_a_id in store_a._get_path()
         assert user_b_id not in store_a._get_path()
@@ -486,8 +431,8 @@ class TestUserIsolation:
         """Settings and secrets should have different but consistent paths."""
         user_id = "test-user-123"
 
-        settings_store = S3SettingsStore(file_store=MagicMock(), user_id=user_id)
-        secrets_store = S3SecretsStore(file_store=MagicMock(), user_id=user_id)
+        settings_store = CognitoS3SettingsStore(file_store=MagicMock(), user_id=user_id)
+        secrets_store = CognitoS3SecretsStore(file_store=MagicMock(), user_id=user_id)
 
         settings_path = settings_store._get_path()
         secrets_path = secrets_store._get_path()
@@ -508,7 +453,7 @@ class TestPathConsistencyWithConversationStore:
     def test_settings_path_uses_same_user_prefix(self):
         """Settings path should use same 'users/{user_id}/' prefix as conversations."""
         user_id = "cognito-abc-123"
-        store = S3SettingsStore(file_store=MagicMock(), user_id=user_id)
+        store = CognitoS3SettingsStore(file_store=MagicMock(), user_id=user_id)
         path = store._get_path()
 
         # Should match pattern: users/{user_id}/settings.json
@@ -517,7 +462,7 @@ class TestPathConsistencyWithConversationStore:
     def test_secrets_path_uses_same_user_prefix(self):
         """Secrets path should use same 'users/{user_id}/' prefix as conversations."""
         user_id = "cognito-abc-123"
-        store = S3SecretsStore(file_store=MagicMock(), user_id=user_id)
+        store = CognitoS3SecretsStore(file_store=MagicMock(), user_id=user_id)
         path = store._get_path()
 
         # Should match pattern: users/{user_id}/secrets.json
@@ -532,7 +477,7 @@ class TestErrorMessages:
         """Error message should explain why user_id is required."""
         mock_config = MockOpenHandsConfig()
         with pytest.raises(ValueError) as exc_info:
-            await S3SettingsStore.get_instance(mock_config, None)
+            await CognitoS3SettingsStore.get_instance(mock_config, None)
 
         error_msg = str(exc_info.value)
         assert "user_id is required" in error_msg
@@ -543,7 +488,7 @@ class TestErrorMessages:
         """Error message should explain why user_id is required."""
         mock_config = MockOpenHandsConfig()
         with pytest.raises(ValueError) as exc_info:
-            await S3SecretsStore.get_instance(mock_config, None)
+            await CognitoS3SecretsStore.get_instance(mock_config, None)
 
         error_msg = str(exc_info.value)
         assert "user_id is required" in error_msg

--- a/docs/designs/upgrade-v1.7.0-feasibility.md
+++ b/docs/designs/upgrade-v1.7.0-feasibility.md
@@ -32,7 +32,7 @@ The fork's 14-file patch set therefore breaks down as (after **verifying each LL
 
 **Important correction from initial draft**: I initially marked 4 LLM-related fork patches as "absorbed in SDK v1.19.1" based on closed upstream issues #2198 and #2247. Reading the actual SDK v1.19.1 source contradicts that. **Only the `max_output_tokens` cap** logic is truly absorbed. Default-credential-chain Bedrock listing, cross-region inference profile enumeration, env-hint detection, AWS_DEFAULT_REGION setdefault, and cross-region prefix stripping for model_info — **all still missing in upstream**. These features must move into the SDK fork (which the agent-server custom Dockerfile already builds from a fork branch) via `apply-sdk-patches.py`.
 
-This shifts SDK-side patches from 4 → ~6 (one drop, four new) and OpenHands-side patches from "drop 4, port 3" to "drop 1, port 7".
+This shifts SDK-side patches from 4 → 8 (one drop, five new) and OpenHands-side patches from "drop 4, port 3" to "drop 1, port 7".
 
 ---
 
@@ -83,7 +83,7 @@ The corresponding upstream **files are deleted**, but the **logic is also missin
 - `openhands/llm/llm.py` patch → port to SDK fork (`openhands-sdk/openhands/sdk/llm/llm.py` and `openhands-sdk/openhands/sdk/llm/utils/model_info.py`); **not patchable in OpenHands repo anymore**
 - `openhands/core/config/llm_config.py` patch (`AWS_DEFAULT_REGION`) → port to SDK fork (`openhands-sdk/openhands/sdk/llm/llm.py:_set_env_side_effects`); **not patchable in OpenHands repo anymore**
 
-This expands SDK-side patches from 4 to **6**. The infra repo's `apply-sdk-patches.py` will need 2 new patches (cross-region prefix stripping + AWS_DEFAULT_REGION setdefault + default credential chain for listing).
+This expands SDK-side patches from 4 to **8**. The infra repo's `apply-sdk-patches.py` will need **5 new patches** (default credential chain for listing, cross-region inference profile enumeration, cross-region prefix stripping, AWS_DEFAULT_REGION setdefault, env-hint trigger for Bedrock listing) and will drop Patch 27 (absorbed in SDK v1.19.1). Patches 23/25/26 carry over with re-anchoring.
 
 ---
 
@@ -186,12 +186,12 @@ Recommendation: patch the SDK side (covers both call sites — listing, and `_li
 1. **Drop 1 patch confirmed absorbed**: SDK Patch 27 (Bedrock max_output_tokens cap — covered by SDK PR #2264).
 2. **Drop 1 obsolete-V0 patch**: `openhands/server/config/server_config.py` — V0 store-class fields removed.
 3. **Port 4 OpenHands patches to V1 paths**: Cognito S3 stores + auth + utils/llm.py env-hint detection → `openhands/app_server/{settings,secrets,user_auth,utils}/`.
-4. **Add 4 NEW SDK patches** in `apply-sdk-patches.py` for Bedrock features the fork carried that are NOT in upstream SDK v1.19.1:
-   - Default credential chain in `_list_bedrock_foundation_models`
-   - Cross-region inference profile enumeration
-   - Cross-region prefix stripping in `get_litellm_model_info`
-   - `AWS_DEFAULT_REGION` setdefault
-   - Env-hint trigger for Bedrock listing in `get_supported_llm_models`
+4. **Add 5 NEW SDK patches** in `apply-sdk-patches.py` for Bedrock features the fork carried that are NOT in upstream SDK v1.19.1:
+   - Default credential chain in `_list_bedrock_foundation_models` (Patch 28)
+   - Cross-region inference profile enumeration (Patch 29)
+   - Cross-region prefix stripping in `get_litellm_model_info` (Patch 30)
+   - `AWS_DEFAULT_REGION` setdefault (Patch 31)
+   - Env-hint trigger for Bedrock listing in `get_supported_llm_models` (Patch 32)
 5. **Treat Patch 21 (multi-tenant verification) as security-critical** — grep patterns must be rewritten for V1 paths or it silently allows shared storage.
 6. **Run full E2E** (`./test/select-e2e-tests.sh --all`) on staging; **must** include a Bedrock-with-IAM-role smoke test (the patch we're forced to keep upstream of the SDK).
 
@@ -205,7 +205,7 @@ While porting them as SDK patches, consider opening upstream PRs against `OpenHa
 
 ## Appendix A: Verification plan (runs before merging the upgrade PR)
 
-1. **Build the agent-server custom image** with new SDK v1.19.1 — confirm `apply-sdk-patches.py` reports all 3 (or 4 if Patch 27 retained) patches applied without "WARNING: pattern not found".
+1. **Build the agent-server custom image** with new SDK v1.19.1 — confirm `apply-sdk-patches.py` reports all 6 patches applied (23, 25, 26, 28/29/32 atomic, 30, 31) without "WARNING: pattern not found" or "ERROR: pattern not found".
 2. **Build the openhands custom image** — confirm `download-fork-patches.sh` 200s on every file in the new (smaller) FILES list and that `apply-startup.sh` reports every "Patch X: ... applied correctly" with no `CRITICAL PATCH FAILURE`.
 3. **Unit tests**: `npm run test`. Expect ~7-8 ARM64 Docker bundling failures (memory: `feedback_deploy_qemu` — install binfmt to skip these).
 4. **Staging deploy**: `./deploy-staging.local.sh`. Confirm sandbox starts, conversation creates.

--- a/docs/designs/upgrade-v1.7.0-feasibility.md
+++ b/docs/designs/upgrade-v1.7.0-feasibility.md
@@ -1,0 +1,268 @@
+# OpenHands v1.6.0 → v1.7.0 Upgrade Feasibility Report
+
+**Author:** zxkane (via Claude Code session)
+**Date:** 2026-05-13
+**Upstream release:** v1.7.0 (2026-05-01), 296 commits since v1.6.0
+**SDK bump:** v1.15.0 → v1.19.1 (4 minor versions)
+**Status:** ⚠️ **Higher-impact than prior upgrades.** Recommendation at the bottom.
+
+---
+
+## TL;DR
+
+v1.7.0 is dominated by a **V0 → V1 cleanup**. Upstream deleted multiple legacy packages
+the fork has been patching since v1.4.0:
+
+- `openhands/llm/` — entire package removed (Bedrock + LLM module gone, logic now in SDK)
+- `openhands/utils/llm.py` — moved to `openhands/app_server/utils/llm.py`
+- `openhands/storage/` — `__init__.py` removed; subdirs `secrets/`, `settings/`, `conversation/` collapsed into `openhands/app_server/{secrets,settings}/`
+- `openhands/storage/data_models/secrets.py` — moved to `openhands/app_server/secrets/secrets_models.py`
+- `openhands/server/config/server_config.py` — kept but explicitly tagged `Legacy-V0`, scheduled for removal "April 1, 2026"; conversation_store / conversation_manager / monitoring_listener fields removed
+
+The fork's 14-file patch set therefore breaks down as (after **verifying each LLM patch against actual SDK v1.19.1 source**, not just upstream PR titles):
+
+| Status                | # files | Notes |
+|-----------------------|---------|-------|
+| ✅ Apply cleanly        | 2       | `app_conversation_service.py`, `db_session_injector.py` |
+| ⚠️ Apply with conflicts | 4       | `live_status_app_conversation_service.py` (17 commits), `app_conversation_router.py`, `webhook_router.py`, `sql_event_callback_service.py`, `app_server/config.py`, `remote_sandbox_service.py` |
+| 🔁 Port to V1 OpenHands paths | 4 | Cognito auth, S3 stores → `openhands/app_server/{user_auth,settings,secrets}/`; fork's `utils/llm.py` env-hint detection → `app_server/utils/llm.py` |
+| 🔁 Port to SDK fork     | 3       | `llm/bedrock.py` default-cred-chain + inference-profile listing, `llm/llm.py` cross-region prefix stripping, `llm_config.py` AWS_DEFAULT_REGION — **none of these are in upstream SDK v1.19.1** |
+| ❌ Drop (V0 obsolete)   | 1       | `server_config.py` (V0 store-class fields removed) |
+| ❌ Drop (truly absorbed in SDK) | ~1 | The `max_output_tokens` half of `llm/llm.py` is covered by SDK PR #2264 |
+
+**Important correction from initial draft**: I initially marked 4 LLM-related fork patches as "absorbed in SDK v1.19.1" based on closed upstream issues #2198 and #2247. Reading the actual SDK v1.19.1 source contradicts that. **Only the `max_output_tokens` cap** logic is truly absorbed. Default-credential-chain Bedrock listing, cross-region inference profile enumeration, env-hint detection, AWS_DEFAULT_REGION setdefault, and cross-region prefix stripping for model_info — **all still missing in upstream**. These features must move into the SDK fork (which the agent-server custom Dockerfile already builds from a fork branch) via `apply-sdk-patches.py`.
+
+This shifts SDK-side patches from 4 → ~6 (one drop, four new) and OpenHands-side patches from "drop 4, port 3" to "drop 1, port 7".
+
+---
+
+## Section 1: Upstream changes that affect the fork
+
+### 1.1 V0 deletions
+
+| Path | Status in v1.7.0 | Upstream removal commit |
+|------|------------------|------------------------|
+| `openhands/llm/__init__.py` | DELETED | `aea611602` ("Remove openhands.llm package (legacy V0 code)") |
+| `openhands/llm/bedrock.py` | DELETED | same |
+| `openhands/llm/llm.py` | DELETED | same |
+| `openhands/utils/llm.py` | MOVED → `openhands/app_server/utils/llm.py` | `18460a346` ("refactor: move openhands.utils to openhands.app_server.utils") |
+| `openhands/core/config/llm_config.py` | DELETED | `2ed36cfa7` ("Remove legacy LLMConfig and all related code") |
+| `openhands/storage/data_models/secrets.py` | DELETED | (storage package collapse) |
+| `openhands/server/config/server_config.py` | PRESENT, marked `Legacy-V0` (removal Apr 1 2026); `conversation_store_class`, `conversation_manager_class`, `monitoring_listener_class` fields removed; remaining fields point to V1 (`openhands.app_server.*`) | various |
+
+### 1.2 V1 paths the fork must now target
+
+| V0 path (v1.6.0)                                           | V1 path (v1.7.0)                                            |
+|------------------------------------------------------------|--------------------------------------------------------------|
+| `openhands.storage.settings.s3_settings_store.S3SettingsStore` | port to `openhands/app_server/settings/` (extends `SettingsStore`) |
+| `openhands.storage.secrets.s3_secrets_store.S3SecretsStore`     | port to `openhands/app_server/secrets/` (extends `SecretsStore`) |
+| `openhands.server.user_auth.cognito_user_auth.CognitoUserAuth`  | port to `openhands/app_server/user_auth/` (extends `UserAuth`) |
+| `openhands.storage.conversation.cognito_file_conversation_store.CognitoFileConversationStore` | **No direct V1 equivalent.** Fork patch on `app_server/config.py` already handles per-user conversation isolation via `CognitoSQLAppConversationInfoServiceInjector` — the V0 store override is redundant. |
+
+### 1.3 SDK upgrades (v1.15.0 → v1.19.1) — verified against actual SDK source
+
+I verified each fork LLM patch against `openhands-sdk` v1.19.1 source. **Initial assumption that SDK PRs #2598 / #2264 fully absorbed the fork's Bedrock work was wrong.** Updated findings:
+
+| Fork patch | What it does | SDK v1.19.1 / upstream v1.7.0 actual status | Verdict |
+|------------|--------------|---------------------------------------------|---------|
+| `llm/bedrock.py:_create_bedrock_client` — default credential chain when no explicit creds | Allows `boto3.client('bedrock')` with no creds → falls through to default chain (IRSA, AWS_PROFILE, EC2 IAM, etc.) | SDK `_list_bedrock_foundation_models` (`openhands-sdk/openhands/sdk/llm/utils/unverified_models.py:34-39`) calls `client.list_foundation_models` with **all three creds passed unconditionally**. No fallback. | ❌ **NOT absorbed** — patch logic lost |
+| `llm/bedrock.py` cross-region inference profile listing | Adds `bedrock/us.anthropic...` model IDs via `paginate('list_inference_profiles')` | SDK only calls `list_foundation_models`. No inference-profile enumeration. | ❌ **NOT absorbed** — patch logic lost |
+| `llm/llm.py` cross-region prefix stripping for model_info lookup | Strips `bedrock/us.\|eu.\|apac.\|global.` prefix to find litellm model_cost entry | SDK `model_info.py:79-88` falls back to `model.split(":")[0]` (strips `:N` version) and `model.split("/")[-1]` (last segment). **Doesn't strip cross-region prefix.** | ⚠️ **Partial** — version stripping yes, region prefix no |
+| `llm/llm.py` Bedrock `max_output_tokens` handling | (a) When `None`, pop `max_completion_tokens`; (b) when `==max_input_tokens`, set None | SDK `llm.py:1259-1304` caps via `max_output_tokens // 2` when `>= context_window`; uses `min(max_tokens, DEFAULT_MAX_OUTPUT_TOKENS_CAP)` for ambiguous case. SDK is more conservative but covers the same failure mode. | ✅ **Absorbed** (different mechanism, same outcome) |
+| `utils/llm.py` env-hint detection for Bedrock listing | Triggers Bedrock listing when `AWS_PROFILE`, `AWS_ROLE_ARN`, `AWS_WEB_IDENTITY_TOKEN_FILE` set, even without explicit creds | SDK `get_supported_llm_models` (`unverified_models.py:69-71`) requires `aws_region_name and aws_access_key_id and aws_secret_access_key` — same as pre-fork V0 | ❌ **NOT absorbed** — IRSA / AWS_PROFILE workflows can't list Bedrock models |
+| `core/config/llm_config.py` `os.environ.setdefault('AWS_DEFAULT_REGION', ...)` | Sets boto3-preferred env var alongside `AWS_REGION_NAME` | SDK sets `AWS_REGION_NAME` only (`llm.py:533-534`); does not set `AWS_DEFAULT_REGION`. boto3 prefers the latter. | ❌ **NOT absorbed** — boto3 may miss region in some auth modes |
+| `apply-sdk-patches.py` Patch 27 "Bedrock max_output_tokens" | Same as `llm/llm.py` (b) above | Same as above row | ✅ **Absorbed** |
+| `apply-sdk-patches.py` Patches 23/25/26 (secret-resume validators) | Filter invalid/masked secrets during conversation resume | No matching upstream PR found in search | 🔍 Likely **still required**; re-anchor patterns against v1.19.1 |
+
+**Conclusion change vs initial report**: I cannot drop `llm/bedrock.py`, `llm/llm.py`, `utils/llm.py`, or `core/config/llm_config.py` patches as "absorbed". The Bedrock features the fork added (default credential chain for listing models, inference-profile enumeration, env-hint detection, AWS_DEFAULT_REGION setdefault) are **NOT in upstream v1.7.0 / SDK v1.19.1**.
+
+The corresponding upstream **files are deleted**, but the **logic is also missing**. So these become **port required** patches, not drop patches:
+
+- `openhands/utils/llm.py` patch → port to `openhands/app_server/utils/llm.py` (still exists; needs env-hint detection + default-cred-chain)
+- `openhands/llm/bedrock.py` patch → port to SDK fork OR a new file under `openhands/app_server/utils/` (since `openhands/llm/` is deleted, this needs a home — easiest is a new fork-only `openhands/app_server/utils/bedrock_listing.py` consumed by the patched `app_server/utils/llm.py`)
+- `openhands/llm/llm.py` patch → port to SDK fork (`openhands-sdk/openhands/sdk/llm/llm.py` and `openhands-sdk/openhands/sdk/llm/utils/model_info.py`); **not patchable in OpenHands repo anymore**
+- `openhands/core/config/llm_config.py` patch (`AWS_DEFAULT_REGION`) → port to SDK fork (`openhands-sdk/openhands/sdk/llm/llm.py:_set_env_side_effects`); **not patchable in OpenHands repo anymore**
+
+This expands SDK-side patches from 4 to **6**. The infra repo's `apply-sdk-patches.py` will need 2 new patches (cross-region prefix stripping + AWS_DEFAULT_REGION setdefault + default credential chain for listing).
+
+---
+
+## Section 2: Per-patch verdict
+
+Each row is one of the 14 files in `docker/download-fork-patches.sh:FILES`, plus the
+4 SDK build-time patches in `docker/agent-server-custom/apply-sdk-patches.py`.
+
+### Build-time fork patches (`download-fork-patches.sh`)
+
+| # | File | Upstream commits since 1.6.0 | Verdict | Action |
+|---|------|------------------------------|---------|--------|
+| 1 | `openhands/app_server/sandbox/remote_sandbox_service.py` | 2 | ✅ Apply | Cherry-pick conflicts likely trivial; re-test pod_status mapping |
+| 2 | `openhands/app_server/app_conversation/app_conversation_service.py` | 0 | ✅ Apply | Should apply cleanly |
+| 3 | `openhands/app_server/app_conversation/live_status_app_conversation_service.py` | **17** | ⚠️ Conflict-heavy | Highest-conflict file, as in prior upgrades. Manual merge of 8 fork commits required. |
+| 4 | `openhands/app_server/app_conversation/app_conversation_router.py` | 5 | ⚠️ Conflicts | Resolvable; verify 404 auto-register flow still works |
+| 5 | `openhands/app_server/event_callback/webhook_router.py` | 5 | ⚠️ Conflicts | Resolvable |
+| 6 | `openhands/app_server/services/db_session_injector.py` | 1 | ✅ Apply | (Already applied cleanly in dry-run cherry-pick) |
+| 7 | `openhands/server/config/server_config.py` | 7 | ❌ **Drop patch entirely** | V0 store-class fields removed upstream; V1 customization happens in `app_server/config.py`. Fork's V0 overrides are redundant. **Remove from `download-fork-patches.sh:FILES`.** |
+| 8 | `openhands/storage/data_models/secrets.py` | DELETED upstream | 🔁 **Port** | Re-target to `openhands/app_server/secrets/secrets_models.py` if the patch logic is still needed. Verify what the fork actually changed (likely `secret_sources` filtering). |
+| 9 | `openhands/app_server/config.py` | 5 | ⚠️ Conflicts | Resolvable; rewires Cognito injectors. |
+| 10 | `openhands/app_server/event_callback/sql_event_callback_service.py` | 1 | ⚠️ Conflict (SQLAlchemy 2.0 style) | Mechanical: rewrite `Column(SQLUUID, ..., default=uuid4)` → `Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)`. Pattern verified during dry-run. |
+| 11 | `openhands/llm/bedrock.py` | DELETED upstream | 🔁 **Port to SDK fork** | Logic NOT in SDK. Default-cred-chain + inference-profile listing must move to SDK fork (`openhands-sdk` patch) or a fork-only file consumed by patched `app_server/utils/llm.py`. **Remove from FILES** (V0 path gone) but **add new SDK patch**. |
+| 12 | `openhands/llm/llm.py` | DELETED upstream | 🔁 **Port to SDK fork** | Cross-region prefix stripping for model_info lookup NOT in SDK. **Remove from FILES** (V0 path gone) but **add new SDK patch** in `openhands-sdk/openhands/sdk/llm/utils/model_info.py`. The `max_output_tokens` part IS absorbed — drop only that piece. |
+| 13 | `openhands/utils/llm.py` | DELETED upstream (moved to `app_server/utils/llm.py`) | 🔁 **Port to V1 path** | Env-hint detection (AWS_PROFILE/AWS_ROLE_ARN/AWS_WEB_IDENTITY_TOKEN_FILE) NOT in SDK. **Re-target FILES entry** to `openhands/app_server/utils/llm.py` and reapply env-hint logic against the v1.7.0 file. |
+| 14 | `openhands/core/config/llm_config.py` | DELETED upstream | 🔁 **Port to SDK fork** | `AWS_DEFAULT_REGION` setdefault NOT in SDK. **Remove from FILES** but **add new SDK patch** in `openhands-sdk/openhands/sdk/llm/llm.py:_set_env_side_effects`. |
+
+### SDK build-time patches (`apply-sdk-patches.py`)
+
+| Patch | Purpose | Verdict | Action |
+|------|---------|---------|--------|
+| 23 | Skip invalid/masked secrets in `agent_context.py` `model_validator` | 🔍 Re-verify | Run patch against SDK v1.19.1 source; insertion pattern may have shifted |
+| 25 | Filter invalid secrets from JSON before `model_validate_json` | 🔍 Re-verify | Same |
+| 26 | Filter invalid `secret_sources` from `ConversationState` | 🔍 Re-verify | v1.6.0 upgrade already had to relocate this anchor (`@property def events`); v1.19.1 may have moved it again |
+| 27 | Fix Bedrock `max_output_tokens` when litellm reports context window | ❌ **Drop** | Absorbed in SDK PR #2264 (merged into v1.13+, present in v1.19.1) |
+| **NEW** | Default credential chain for `_list_bedrock_foundation_models` (no explicit creds → boto3 default chain) | 🆕 **Add** | SDK `openhands-sdk/openhands/sdk/llm/utils/unverified_models.py:21-50` — make all three creds optional, omit when falsy |
+| **NEW** | Cross-region inference profile enumeration in `_list_bedrock_foundation_models` | 🆕 **Add** | Same file — add `paginate('list_inference_profiles', typeEquals='SYSTEM_DEFINED')` |
+| **NEW** | Cross-region prefix stripping for `get_litellm_model_info` | 🆕 **Add** | SDK `openhands-sdk/openhands/sdk/llm/utils/model_info.py:79-90` — add `re.sub(r'^bedrock/(us\|eu\|apac\|global)\.', 'bedrock/', model)` fallback |
+| **NEW** | `AWS_DEFAULT_REGION` setdefault alongside `AWS_REGION_NAME` | 🆕 **Add** | SDK `openhands-sdk/openhands/sdk/llm/llm.py:533-534` — `os.environ.setdefault('AWS_DEFAULT_REGION', ...)` |
+| **NEW** | Bedrock env-hint listing in `get_supported_llm_models` | 🆕 **Add** | SDK `unverified_models.py:69-75` — accept env hints (AWS_PROFILE/AWS_ROLE_ARN/AWS_WEB_IDENTITY_TOKEN_FILE) as trigger to call `_list_bedrock_foundation_models` |
+
+### New V1 patches the fork must add
+
+These are **net-new** files we'll need under `openhands/app_server/` to replace V0 customization:
+
+| New fork file | Replaces V0 | Notes |
+|---------------|-------------|-------|
+| `openhands/app_server/settings/cognito_s3_settings_store.py` | `openhands/storage/settings/s3_settings_store.py` | Extend new `SettingsStore` ABC; reuse existing S3 path logic (`users/{user_id}/settings/...`) |
+| `openhands/app_server/secrets/cognito_s3_secrets_store.py` | `openhands/storage/secrets/s3_secrets_store.py` | Extend new `SecretsStore` ABC; reuse KMS envelope encryption |
+| `openhands/app_server/user_auth/cognito_user_auth.py` | `openhands/server/user_auth/cognito_user_auth.py` | Extend new `UserAuth` ABC; verify JWT decoding hooks still match |
+
+The wiring then happens via the existing `openhands/app_server/config.py` patch
+(commit `00130abd0` rewrites the V1 injectors for app_conversation_info; we'll add
+similar overrides for settings/secrets/user_auth).
+
+### Bedrock-listing port (OpenHands `app_server/utils/llm.py`)
+
+The fork's env-hint detection from `openhands/utils/llm.py` re-targets to the renamed file. But the V1 file at v1.7.0 **doesn't call `_list_bedrock_foundation_models` at all** — Bedrock listing is now SDK-side via `get_supported_llm_models`, called from somewhere else. We need to either:
+- Re-add the Bedrock listing trigger in `app_server/utils/llm.py` (if it ever called the SDK helper directly), OR
+- Patch the SDK's `get_supported_llm_models` (more invasive but solves the problem at source).
+
+Recommendation: patch the SDK side (covers both call sites — listing, and `_list_bedrock_foundation_models` default-cred-chain) and treat the OpenHands-side `utils/llm.py` patch as obsolete after that.
+
+---
+
+## Section 3: Risks
+
+| # | Risk | Likelihood | Mitigation |
+|---|------|-----------|------------|
+| 1 | Cognito V1 user-auth port misses an injection point — auth quietly falls back to default | Med | Add `apply-startup.sh` verification grep that fails the container if the V1 `CognitoUserAuth` injector isn't wired. Run E2E auth flow before declaring deploy ready. |
+| 2 | S3SettingsStore / S3SecretsStore lose user-scoped path on V1 port (settings written to a shared key) | High if not tested | Same hard-fail verification in `apply-startup.sh`. Run multi-tenant E2E (test1 + test2 users; assert no cross-user reads). |
+| 3 | Bedrock SDK absorption misses a credential mode the fork supported (e.g., custom endpoint URL) | Med | Pre-deploy: read SDK v1.19.1 `LLM` Bedrock config code; cross-check against fork patch's full feature surface. Staging E2E with a non-trivial Bedrock setup (named profile, e.g.). |
+| 4 | `live_status_app_conversation_service.py` 17-commit upstream churn breaks fork's resume / sandbox-recreation logic | High | Same as v1.6.0 upgrade — manual cherry-pick + careful re-read. E2E pause/resume + agent-replacement test. |
+| 5 | `openhands/storage/data_models/secrets.py` deletion implies upstream tests for fork-patched secret-source filtering may now reside in V1 paths | Low | Trace the fork patch's *actual* logic; if it duplicates upstream behavior, drop entirely. |
+| 6 | SDK v1.19.1 changes patch-anchor lines for SDK Patches 23/25/26 | Med | Run `apply-sdk-patches.py` dry-run during agent-server build; fail fast on missing pattern. |
+| 7 | Existing staging data: V0 settings/secrets paths in S3 won't be read by new V1 stores | Med | Either (a) port path layout 1:1 in V1 store (preferred — `users/{user_id}/settings/...`), or (b) one-shot data migration. (a) is simpler if the V1 `SettingsStore` ABC is flexible enough. |
+
+---
+
+## Section 4: Effort estimate
+
+| Phase | Effort | Notes |
+|------|--------|-------|
+| Fork branch (cherry-pick + V1 ports) | 1.5–2 days | 20 cherry-picks, 3 new V1 files (Cognito S3 stores + auth), conflict resolution in `live_status_app_conversation_service.py` |
+| **SDK fork branch** for Bedrock features | 0.5–1 day | New step. SDK branch off v1.19.1 with: default-cred-chain in `_list_bedrock_foundation_models`, cross-region inference profile listing, cross-region prefix stripping in `model_info.py`, `AWS_DEFAULT_REGION` setdefault, env-hint trigger in `get_supported_llm_models`. |
+| Infra: `download-fork-patches.sh` rewrite (drop V0-deleted files, add V1 ports), Dockerfile, compute-stack.ts, agent-server-custom SDK pin to v1.19.1 + new patches | 0.5 day | Mechanical, well-trodden |
+| `apply-startup.sh` rewrite (Patch 21 verification gates new V1 paths; drop V0 verifications) | 0.5 day | Critical — wrong patterns silently disable security |
+| `apply-sdk-patches.py` re-verify against v1.19.1 + add 4 new Bedrock patches | 1 day | Drop Patch 27 (absorbed); re-anchor 23/25/26; add 4 Bedrock patches |
+| Local build + unit tests | 0.5 day | Expect failures from typed-tests on removed modules |
+| Staging deploy + E2E (`select-e2e-tests.sh --all`) | 1 day | Major upgrade — full E2E |
+| Buffer for V1-port surprises | 1 day | High likelihood of edge cases in store ports |
+| **Total** | **~6.5–7 working days** | Up from initial 5-day estimate. Reason: I incorrectly assumed Bedrock patches were absorbed; verifying SDK source showed they aren't. |
+
+---
+
+## Section 5: Recommendation
+
+**Proceed with the upgrade**, on the following terms (corrected after verifying SDK source):
+
+1. **Drop 1 patch confirmed absorbed**: SDK Patch 27 (Bedrock max_output_tokens cap — covered by SDK PR #2264).
+2. **Drop 1 obsolete-V0 patch**: `openhands/server/config/server_config.py` — V0 store-class fields removed.
+3. **Port 4 OpenHands patches to V1 paths**: Cognito S3 stores + auth + utils/llm.py env-hint detection → `openhands/app_server/{settings,secrets,user_auth,utils}/`.
+4. **Add 4 NEW SDK patches** in `apply-sdk-patches.py` for Bedrock features the fork carried that are NOT in upstream SDK v1.19.1:
+   - Default credential chain in `_list_bedrock_foundation_models`
+   - Cross-region inference profile enumeration
+   - Cross-region prefix stripping in `get_litellm_model_info`
+   - `AWS_DEFAULT_REGION` setdefault
+   - Env-hint trigger for Bedrock listing in `get_supported_llm_models`
+5. **Treat Patch 21 (multi-tenant verification) as security-critical** — grep patterns must be rewritten for V1 paths or it silently allows shared storage.
+6. **Run full E2E** (`./test/select-e2e-tests.sh --all`) on staging; **must** include a Bedrock-with-IAM-role smoke test (the patch we're forced to keep upstream of the SDK).
+
+Alternative (skip 1.7.0): not recommended — v1.8.x will inherit the V0→V1 cleanup already shipped here, so the same port work is unavoidable. Doing it on 1.7.0 keeps patch deltas smaller per release and keeps pace with upstream CVE / dependency fixes.
+
+### Optional follow-up: contribute the Bedrock features upstream
+
+While porting them as SDK patches, consider opening upstream PRs against `OpenHands/software-agent-sdk` for the four Bedrock features. They're general-purpose (not zxkane-specific) and the SDK already accepted PR #2598 for similar AWS auth work — there's a good chance maintainers would merge them. Upstreaming would let us drop these patches in v1.8.x.
+
+---
+
+## Appendix A: Verification plan (runs before merging the upgrade PR)
+
+1. **Build the agent-server custom image** with new SDK v1.19.1 — confirm `apply-sdk-patches.py` reports all 3 (or 4 if Patch 27 retained) patches applied without "WARNING: pattern not found".
+2. **Build the openhands custom image** — confirm `download-fork-patches.sh` 200s on every file in the new (smaller) FILES list and that `apply-startup.sh` reports every "Patch X: ... applied correctly" with no `CRITICAL PATCH FAILURE`.
+3. **Unit tests**: `npm run test`. Expect ~7-8 ARM64 Docker bundling failures (memory: `feedback_deploy_qemu` — install binfmt to skip these).
+4. **Staging deploy**: `./deploy-staging.local.sh`. Confirm sandbox starts, conversation creates.
+5. **E2E suite**: `./test/select-e2e-tests.sh --all` — minimum gate before merge.
+6. **Multi-tenant smoke test**: create two test users, verify settings/secrets are user-scoped at `users/{user_id}/...` in S3, verify one user cannot list another user's conversations.
+7. **Bedrock smoke test**: with a Bedrock-only LLM profile (no API key, IAM-based auth), verify a one-shot conversation completes — covers credential-chain fallback.
+
+---
+
+## Appendix B: Files staying in `download-fork-patches.sh` (proposed, corrected)
+
+```
+# Down from 14 to ~12 files (minor reduction; Bedrock features move to SDK patches instead)
+openhands/app_server/sandbox/remote_sandbox_service.py
+openhands/app_server/app_conversation/app_conversation_service.py
+openhands/app_server/app_conversation/live_status_app_conversation_service.py
+openhands/app_server/app_conversation/app_conversation_router.py
+openhands/app_server/event_callback/webhook_router.py
+openhands/app_server/services/db_session_injector.py
+openhands/app_server/config.py
+openhands/app_server/event_callback/sql_event_callback_service.py
+# new V1-port files added by the fork branch:
+openhands/app_server/user_auth/cognito_user_auth.py
+openhands/app_server/settings/cognito_s3_settings_store.py
+openhands/app_server/secrets/cognito_s3_secrets_store.py
+# possibly: openhands/app_server/utils/llm.py — only if env-hint detection is still required after SDK patches absorb the same logic
+```
+
+Removed (V0-deleted, no logic to port to OpenHands repo): `openhands/server/config/server_config.py`, `openhands/storage/data_models/secrets.py`, `openhands/llm/bedrock.py`, `openhands/llm/llm.py`, `openhands/core/config/llm_config.py`.
+
+`openhands/utils/llm.py` → re-target to `openhands/app_server/utils/llm.py` only if SDK-side patches don't fully cover it.
+
+The 3 new V1 files (Cognito S3 stores + auth) are *fork-only* (don't exist upstream) — they're added by the fork branch, then materialized into the build via `download-fork-patches.sh`.
+
+## Appendix C: New SDK patches to add to `apply-sdk-patches.py`
+
+```
+Patch 28 (NEW): Default credential chain for _list_bedrock_foundation_models
+  Target: openhands-sdk/openhands/sdk/llm/utils/unverified_models.py:21-50
+  Make all three creds optional; omit from boto3.client kwargs when falsy
+
+Patch 29 (NEW): Cross-region inference profile listing
+  Target: same file
+  Add paginator('list_inference_profiles', typeEquals='SYSTEM_DEFINED') after
+  list_foundation_models; merge results
+
+Patch 30 (NEW): Cross-region prefix stripping for get_litellm_model_info
+  Target: openhands-sdk/openhands/sdk/llm/utils/model_info.py:79-90
+  Add fallback: re.sub(r'^bedrock/(us|eu|apac|global)\.', 'bedrock/', model)
+
+Patch 31 (NEW): AWS_DEFAULT_REGION setdefault in _set_env_side_effects
+  Target: openhands-sdk/openhands/sdk/llm/llm.py:533-534
+  After AWS_REGION_NAME assignment, add os.environ.setdefault('AWS_DEFAULT_REGION', ...)
+
+Patch 32 (NEW, optional): Env-hint trigger for Bedrock listing
+  Target: openhands-sdk/openhands/sdk/llm/utils/unverified_models.py:69-75
+  Trigger _list_bedrock_foundation_models when AWS_PROFILE/AWS_ROLE_ARN/
+  AWS_WEB_IDENTITY_TOKEN_FILE set, even without explicit creds (works with
+  Patch 28). Skip if Patch 28 alone proves sufficient in staging E2E.
+```

--- a/lambda/conversation-delete/index.ts
+++ b/lambda/conversation-delete/index.ts
@@ -70,16 +70,10 @@ interface DeleteEvent {
 }
 
 /**
- * Delete all S3 objects under the conversation prefix.
+ * Delete all S3 objects under the given prefix.
  * Paginates through ListObjectsV2 and batch-deletes up to 1000 objects per call.
  */
-async function deleteS3Objects(conversationId: string): Promise<number> {
-  if (!DATA_BUCKET) {
-    logger.info('DATA_BUCKET not configured, skipping S3 cleanup');
-    return 0;
-  }
-
-  const prefix = `conversations/${conversationId}/`;
+async function deletePrefix(prefix: string): Promise<number> {
   let deletedCount = 0;
   let continuationToken: string | undefined;
 
@@ -101,14 +95,42 @@ async function deleteS3Objects(conversationId: string): Promise<number> {
         Delete: { Objects: objects, Quiet: true },
       }));
       deletedCount += objects.length;
-      logger.info('Deleted S3 objects batch', { count: objects.length, total: deletedCount });
+      logger.info('Deleted S3 objects batch', { prefix, count: objects.length, total: deletedCount });
     }
 
     continuationToken = listResponse.NextContinuationToken;
   } while (continuationToken);
 
-  logger.info('S3 cleanup complete', { conversationId, deletedCount });
   return deletedCount;
+}
+
+/**
+ * Delete all S3 objects for a conversation.
+ *
+ * Two layouts coexist:
+ * - V0/legacy: `conversations/{conversation_id}/` (older deployments, pre-v1.6)
+ * - V1: `users/{user_id}/v1_conversations/{conversation_id}/` (current AwsEventService layout)
+ *
+ * Both prefixes are cleaned to handle conversations created at any version.
+ */
+async function deleteS3Objects(conversationId: string, userId: string): Promise<number> {
+  if (!DATA_BUCKET) {
+    logger.info('DATA_BUCKET not configured, skipping S3 cleanup');
+    return 0;
+  }
+
+  const prefixes = [
+    `conversations/${conversationId}/`,
+    `users/${userId}/v1_conversations/${conversationId}/`,
+  ];
+
+  let total = 0;
+  for (const prefix of prefixes) {
+    total += await deletePrefix(prefix);
+  }
+
+  logger.info('S3 cleanup complete', { conversationId, userId, deletedCount: total });
+  return total;
 }
 
 /**
@@ -202,7 +224,7 @@ export async function handler(event: DeleteEvent): Promise<{ statusCode: number;
 
   // Execute all cleanup steps — continue even if individual steps fail
   const [s3Count] = await Promise.all([
-    deleteS3Objects(conversation_id),
+    deleteS3Objects(conversation_id, user_id),
   ]);
 
   deleteEfsWorkspace(conversation_id);

--- a/lambda/conversation-delete/index.ts
+++ b/lambda/conversation-delete/index.ts
@@ -90,12 +90,23 @@ async function deletePrefix(prefix: string): Promise<number> {
       .map((obj: _Object) => ({ Key: obj.Key! }));
 
     if (objects.length > 0) {
-      await s3.send(new DeleteObjectsCommand({
+      // Quiet=false so per-key Errors are returned (e.g. AccessDenied) — without
+      // this, IAM misconfigurations look like successes and orphan S3 objects.
+      const deleteResponse = await s3.send(new DeleteObjectsCommand({
         Bucket: DATA_BUCKET,
-        Delete: { Objects: objects, Quiet: true },
+        Delete: { Objects: objects, Quiet: false },
       }));
-      deletedCount += objects.length;
-      logger.info('Deleted S3 objects batch', { prefix, count: objects.length, total: deletedCount });
+      const errors = deleteResponse.Errors || [];
+      const succeeded = objects.length - errors.length;
+      deletedCount += succeeded;
+      if (errors.length > 0) {
+        logger.error('S3 batch delete had errors', {
+          prefix,
+          errorCount: errors.length,
+          firstError: { code: errors[0].Code, key: errors[0].Key, message: errors[0].Message },
+        });
+      }
+      logger.info('Deleted S3 objects batch', { prefix, count: succeeded, total: deletedCount });
     }
 
     continuationToken = listResponse.NextContinuationToken;

--- a/lib/compute-stack.ts
+++ b/lib/compute-stack.ts
@@ -37,7 +37,16 @@ const DEFAULT_OPENHANDS_VERSION = '1.7.0';
 // Multi-arch manifest list digest (linux/amd64 + linux/arm64) for openhands/openhands:1.7.0.
 // Refresh: docker buildx imagetools inspect docker.openhands.dev/openhands/openhands:<version>
 const DEFAULT_OPENHANDS_IMAGE_DIGEST = 'sha256:916abcb15cc451d96853bd41c55117bb2ff3de0b9914cdcd861d338055798dc6';
-const DEFAULT_RUNTIME_VERSION = '1.7-nikolaik';
+// Upstream did not publish a `1.7-nikolaik` runtime image — the V0 runtime
+// image is being phased out in favor of V1's agent-server binary (built
+// from source in docker/agent-server-custom/). For Fargate sandboxes the
+// runtime image is still referenced via SANDBOX_RUNTIME_CONTAINER_IMAGE
+// but is not actually launched (RemoteSandboxService uses the agent-server
+// image instead). `latest-nikolaik` is currently identical to `1.6-nikolaik`
+// (same manifest digest), so the bump is a no-op; the version is kept as a
+// recognisable label for future re-pinning if upstream resumes publishing
+// versioned runtime tags.
+const DEFAULT_RUNTIME_VERSION = 'latest-nikolaik';
 
 /**
  * Read OpenHands config.toml from the config directory.
@@ -435,7 +444,11 @@ export class ComputeStack extends cdk.Stack {
       WORKSPACE_BASE: '/data/openhands/workspace',
       LOG_ALL_EVENTS: 'true',
       HIDE_LLM_SETTINGS: 'false',
-      USER_AUTH_CLASS: 'openhands.server.user_auth.cognito_user_auth.CognitoUserAuth',
+      // V1 path (was openhands.server.user_auth.cognito_user_auth.CognitoUserAuth in v1.6).
+      // This env var is read by openhands.server.shared at startup to override
+      // server_config.user_auth_class. It must point at the V1 module our fork
+      // installs into /app/openhands/app_server/user_auth/cognito_user_auth.py.
+      USER_AUTH_CLASS: 'openhands.app_server.user_auth.cognito_user_auth.CognitoUserAuth',
       // LLM_MODEL removed — model is configured via config.toml [llm].model
       // and overridden per-user via Settings.llm_model (saved in S3).
       // Hardcoding LLM_MODEL env var would override user's model selection.

--- a/lib/compute-stack.ts
+++ b/lib/compute-stack.ts
@@ -34,11 +34,9 @@ import {
  */
 const DEFAULT_OPENHANDS_VERSION = '1.7.0';
 // Pin base image to exact manifest digest to prevent Docker build cache from using stale layers.
-// Update: docker manifest inspect docker.openhands.dev/openhands/openhands:<version> | jq '.digest'
-// TODO(PR #81): replace with the actual sha256 of openhands/openhands:1.7.0 once
-// the image is pulled in CI / staging — placeholder is the v1.6.0 digest so synth
-// keeps producing diffs locally; staging deploy must update this before merge.
-const DEFAULT_OPENHANDS_IMAGE_DIGEST = 'sha256:5c0dc26f467bf8e47a6e76308edb7a30af4084b17e23a3460b5467008b12111b';
+// Multi-arch manifest list digest (linux/amd64 + linux/arm64) for openhands/openhands:1.7.0.
+// Refresh: docker buildx imagetools inspect docker.openhands.dev/openhands/openhands:<version>
+const DEFAULT_OPENHANDS_IMAGE_DIGEST = 'sha256:916abcb15cc451d96853bd41c55117bb2ff3de0b9914cdcd861d338055798dc6';
 const DEFAULT_RUNTIME_VERSION = '1.7-nikolaik';
 
 /**

--- a/lib/compute-stack.ts
+++ b/lib/compute-stack.ts
@@ -32,11 +32,14 @@ import {
  * Default Docker image versions - update these when new stable versions are released.
  * Latest release: https://github.com/OpenHands/OpenHands/releases
  */
-const DEFAULT_OPENHANDS_VERSION = '1.6.0';
+const DEFAULT_OPENHANDS_VERSION = '1.7.0';
 // Pin base image to exact manifest digest to prevent Docker build cache from using stale layers.
 // Update: docker manifest inspect docker.openhands.dev/openhands/openhands:<version> | jq '.digest'
+// TODO(PR #81): replace with the actual sha256 of openhands/openhands:1.7.0 once
+// the image is pulled in CI / staging — placeholder is the v1.6.0 digest so synth
+// keeps producing diffs locally; staging deploy must update this before merge.
 const DEFAULT_OPENHANDS_IMAGE_DIGEST = 'sha256:5c0dc26f467bf8e47a6e76308edb7a30af4084b17e23a3460b5467008b12111b';
-const DEFAULT_RUNTIME_VERSION = '1.6-nikolaik';
+const DEFAULT_RUNTIME_VERSION = '1.7-nikolaik';
 
 /**
  * Read OpenHands config.toml from the config directory.

--- a/lib/sandbox-stack.ts
+++ b/lib/sandbox-stack.ts
@@ -822,10 +822,16 @@ export class SandboxStack extends cdk.Stack {
 
     registryTable.grantReadWriteData(deletionLambda);
 
-    // S3 permissions for conversation data cleanup
+    // S3 permissions for conversation data cleanup.
+    // Two layouts coexist:
+    //   - V0/legacy: conversations/{conversation_id}/
+    //   - V1: users/{user_id}/v1_conversations/{conversation_id}/  (AwsEventService since 1.6.0)
+    // The Lambda lists/deletes both prefixes; both must be writable.
     if (props.dataBucket) {
       props.dataBucket.grantRead(deletionLambda, 'conversations/*');
       props.dataBucket.grantDelete(deletionLambda, 'conversations/*');
+      props.dataBucket.grantRead(deletionLambda, 'users/*/v1_conversations/*');
+      props.dataBucket.grantDelete(deletionLambda, 'users/*/v1_conversations/*');
     }
 
     // RDS Data API + Secrets Manager for Aurora conversation cleanup

--- a/lib/user-config-stack.ts
+++ b/lib/user-config-stack.ts
@@ -73,6 +73,15 @@ export class UserConfigStack extends cdk.Stack {
         assetExcludes: ['.venv', '__pycache__', '*.pyc', 'test_*.py', '.pytest_cache'],
         // Use SOURCE hash to ensure consistent asset hash across environments
         assetHashType: cdk.AssetHashType.SOURCE,
+        // Force uv to use Python 3.12 inside the bundling container so it
+        // matches the Lambda runtime above. Without this, uv defaults to the
+        // lowest Python that satisfies `requires-python` (currently 3.11
+        // inside the CDK bundling image), and pydantic-core 2.41.5 has no
+        // cp311-aarch64 wheel — uv would then try to compile from source and
+        // fail because the bundling container has no Rust toolchain.
+        environment: {
+          UV_PYTHON: '3.12',
+        },
       },
     });
 

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1502,7 +1502,7 @@ security_analyzer = "llm"",
               "Timeout": 10,
             },
             "Image": {
-              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:6a0d401e6f0d6ae3b7f28689d3160cdfc956c21484bef376c0a48800a828f268",
+              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:f828f2e1665609b512cf4965485e4adeded92cab2de27148c7654e0dc8d70aa3",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1502,7 +1502,7 @@ security_analyzer = "llm"",
               "Timeout": 10,
             },
             "Image": {
-              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:6989b9b591c6aceca8c12660a6633c9969615dd0cc990cc626a68f46db4e2994",
+              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:fe85b42dad55d40421d69ab9bfef3daa29456936fecb7fde66932ed4e1778402",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1329,7 +1329,7 @@ exports[`OpenHands Infrastructure Stacks ComputeStack matches snapshot 1`] = `
               {
                 "Name": "SANDBOX_RUNTIME_CONTAINER_IMAGE",
                 "Value": {
-                  "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:6d50db6af4a1010108c5ef8ed623d7114516e939f05e505cbad7c230cea4e744",
+                  "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:6f582a364ab5879a4fe0423e5b1a152fe57c8d7ed3a428dbb88804b93e2b9550",
                 },
               },
               {
@@ -1397,7 +1397,7 @@ exports[`OpenHands Infrastructure Stacks ComputeStack matches snapshot 1`] = `
               },
               {
                 "Name": "AGENT_SERVER_IMAGE_TAG",
-                "Value": "2f8488ba6943116de97881d9999741e4636f108c6df72b5bee8c7e3f55ddd238",
+                "Value": "8fe47606b25c164173959e8779176de6dac89448888358b7d01d66f5f3b1c7ca",
               },
               {
                 "Name": "AGENT_ENABLE_BROWSING",
@@ -1502,7 +1502,7 @@ security_analyzer = "llm"",
               "Timeout": 10,
             },
             "Image": {
-              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:f0f2b4cd19d66b006010f0bf4b91e55044057d4a09e1676e5f0cc6b0e25313fc",
+              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:e2dc7625759a9486146716276f1420cdf7710a0220d4b0571eab73e76189d2c2",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -1721,7 +1721,7 @@ security_analyzer = "llm"",
         "Name": "/openhands/docker/openhands-version",
         "Tier": "Standard",
         "Type": "String",
-        "Value": "1.6.0",
+        "Value": "1.7.0",
       },
       "Type": "AWS::SSM::Parameter",
     },
@@ -1961,7 +1961,7 @@ security_analyzer = "llm"",
         "Name": "/openhands/docker/runtime-version",
         "Tier": "Standard",
         "Type": "String",
-        "Value": "1.6-nikolaik",
+        "Value": "1.7-nikolaik",
       },
       "Type": "AWS::SSM::Parameter",
     },

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1502,7 +1502,7 @@ security_analyzer = "llm"",
               "Timeout": 10,
             },
             "Image": {
-              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:e2dc7625759a9486146716276f1420cdf7710a0220d4b0571eab73e76189d2c2",
+              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:6989b9b591c6aceca8c12660a6633c9969615dd0cc990cc626a68f46db4e2994",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1502,7 +1502,7 @@ security_analyzer = "llm"",
               "Timeout": 10,
             },
             "Image": {
-              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:f828f2e1665609b512cf4965485e4adeded92cab2de27148c7654e0dc8d70aa3",
+              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:e4892eeab434640bbc10be57f39d1438a16122061d87914497eba4b245ef0ade",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1502,7 +1502,7 @@ security_analyzer = "llm"",
               "Timeout": 10,
             },
             "Image": {
-              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:befe516317b68493a837756cb2ed8edd98d6d95466a4b6e557bde3051b2ab1d8",
+              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:6a0d401e6f0d6ae3b7f28689d3160cdfc956c21484bef376c0a48800a828f268",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1502,7 +1502,7 @@ security_analyzer = "llm"",
               "Timeout": 10,
             },
             "Image": {
-              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:fe85b42dad55d40421d69ab9bfef3daa29456936fecb7fde66932ed4e1778402",
+              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:9081e5654b500bb326a8861a395cdffa89df1b3aba0750ab550e241e8e94276a",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1502,7 +1502,7 @@ security_analyzer = "llm"",
               "Timeout": 10,
             },
             "Image": {
-              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:9081e5654b500bb326a8861a395cdffa89df1b3aba0750ab550e241e8e94276a",
+              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:befe516317b68493a837756cb2ed8edd98d6d95466a4b6e557bde3051b2ab1d8",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1502,7 +1502,7 @@ security_analyzer = "llm"",
               "Timeout": 10,
             },
             "Image": {
-              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:e4892eeab434640bbc10be57f39d1438a16122061d87914497eba4b245ef0ade",
+              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:4ba13ca3c8d552e9dc18a99c98e27e7f2d99a94bffcb0ad0fdea4db1f7b26edb",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1502,7 +1502,7 @@ security_analyzer = "llm"",
               "Timeout": 10,
             },
             "Image": {
-              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:de7b28b7946c2ca51094a1173c2b3e4718e450c1b6b375bb5badc48681e34d54",
+              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:15427f92982a1f1f84a2437b11831d0a0a251f82523a4accb18efdf741a270ce",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1502,7 +1502,7 @@ security_analyzer = "llm"",
               "Timeout": 10,
             },
             "Image": {
-              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:4ba13ca3c8d552e9dc18a99c98e27e7f2d99a94bffcb0ad0fdea4db1f7b26edb",
+              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:de7b28b7946c2ca51094a1173c2b3e4718e450c1b6b375bb5badc48681e34d54",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1329,7 +1329,7 @@ exports[`OpenHands Infrastructure Stacks ComputeStack matches snapshot 1`] = `
               {
                 "Name": "SANDBOX_RUNTIME_CONTAINER_IMAGE",
                 "Value": {
-                  "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:6f582a364ab5879a4fe0423e5b1a152fe57c8d7ed3a428dbb88804b93e2b9550",
+                  "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:bc79f5b244ecc004e45131d0b9b4366aec71cabda6dc7b40b22783f26ae4a033",
                 },
               },
               {
@@ -1350,7 +1350,7 @@ exports[`OpenHands Infrastructure Stacks ComputeStack matches snapshot 1`] = `
               },
               {
                 "Name": "USER_AUTH_CLASS",
-                "Value": "openhands.server.user_auth.cognito_user_auth.CognitoUserAuth",
+                "Value": "openhands.app_server.user_auth.cognito_user_auth.CognitoUserAuth",
               },
               {
                 "Name": "LLM_AWS_REGION_NAME",
@@ -1961,7 +1961,7 @@ security_analyzer = "llm"",
         "Name": "/openhands/docker/runtime-version",
         "Tier": "Standard",
         "Type": "String",
-        "Value": "1.7-nikolaik",
+        "Value": "latest-nikolaik",
       },
       "Type": "AWS::SSM::Parameter",
     },

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1397,7 +1397,7 @@ exports[`OpenHands Infrastructure Stacks ComputeStack matches snapshot 1`] = `
               },
               {
                 "Name": "AGENT_SERVER_IMAGE_TAG",
-                "Value": "8fe47606b25c164173959e8779176de6dac89448888358b7d01d66f5f3b1c7ca",
+                "Value": "6be4e331e1c282f14468f88c021486698f219ac096f08ccab7a60eb0cdd713d8",
               },
               {
                 "Name": "AGENT_ENABLE_BROWSING",

--- a/test/conversation-delete.test.ts
+++ b/test/conversation-delete.test.ts
@@ -50,12 +50,18 @@ describe('Conversation Deletion Lambda', () => {
   });
 
   test('deletes conversation data across all storage layers', async () => {
-    s3Mock.on(ListObjectsV2Command).resolves({
-      Contents: [
-        { Key: 'conversations/conv-1/event1.json' },
-        { Key: 'conversations/conv-1/event2.json' },
-      ],
-    });
+    s3Mock.on(ListObjectsV2Command)
+      .resolvesOnce({
+        Contents: [
+          { Key: 'conversations/conv-1/event1.json' },
+          { Key: 'conversations/conv-1/event2.json' },
+        ],
+      })
+      .resolvesOnce({
+        Contents: [
+          { Key: 'users/user-1/v1_conversations/conv-1/event3.json' },
+        ],
+      });
     s3Mock.on(DeleteObjectsCommand).resolves({});
     rdsMock.on(ExecuteStatementCommand).resolves({});
     ddbMock.on(DeleteItemCommand).resolves({});
@@ -69,21 +75,19 @@ describe('Conversation Deletion Lambda', () => {
     const body = JSON.parse(result.body);
     expect(body.deleted).toBe(true);
     expect(body.conversation_id).toBe('conv-1');
-    expect(body.s3_objects_deleted).toBe(2);
+    expect(body.s3_objects_deleted).toBe(3);
 
-    // Verify S3: correct prefix used for listing
+    // Verify S3: both legacy and V1 prefixes are listed
     const listCalls = s3Mock.commandCalls(ListObjectsV2Command);
-    expect(listCalls.length).toBe(1);
-    expect(listCalls[0].args[0].input.Prefix).toBe('conversations/conv-1/');
+    expect(listCalls.length).toBe(2);
+    const prefixes = listCalls.map(c => c.args[0].input.Prefix);
+    expect(prefixes).toContain('conversations/conv-1/');
+    expect(prefixes).toContain('users/user-1/v1_conversations/conv-1/');
     expect(listCalls[0].args[0].input.Bucket).toBe('test-data-bucket');
 
-    // Verify S3: correct keys passed to batch delete, with Quiet mode
+    // Verify S3: deletes happened for both prefixes (Quiet mode)
     const deleteCalls = s3Mock.commandCalls(DeleteObjectsCommand);
-    expect(deleteCalls.length).toBe(1);
-    expect(deleteCalls[0].args[0].input.Delete?.Objects).toEqual([
-      { Key: 'conversations/conv-1/event1.json' },
-      { Key: 'conversations/conv-1/event2.json' },
-    ]);
+    expect(deleteCalls.length).toBe(2);
     expect(deleteCalls[0].args[0].input.Delete?.Quiet).toBe(true);
 
     // Verify EFS: correct path used (mount + conversation_id, not the mount root)
@@ -105,7 +109,22 @@ describe('Conversation Deletion Lambda', () => {
     expect(ddbCalls[0].args[0].input.Key?.conversation_id?.S).toBe('conv-1');
   });
 
-  test('S3 deletion uses correct prefix and does not leak to other conversations', async () => {
+  test('deletes both legacy and V1 S3 prefixes', async () => {
+    s3Mock.on(ListObjectsV2Command).resolves({ Contents: [] });
+    rdsMock.on(ExecuteStatementCommand).resolves({});
+    ddbMock.on(DeleteItemCommand).resolves({});
+
+    await handler({ conversation_id: 'conv-v1', user_id: 'cognito-sub-abc' });
+
+    const listCalls = s3Mock.commandCalls(ListObjectsV2Command);
+    const prefixes = listCalls.map(c => c.args[0].input.Prefix).sort();
+    expect(prefixes).toEqual([
+      'conversations/conv-v1/',
+      'users/cognito-sub-abc/v1_conversations/conv-v1/',
+    ]);
+  });
+
+  test('S3 deletion uses correct prefixes and does not leak to other conversations', async () => {
     s3Mock.on(ListObjectsV2Command).resolves({
       Contents: [
         { Key: 'conversations/target-conv/event1.json' },
@@ -117,12 +136,15 @@ describe('Conversation Deletion Lambda', () => {
 
     await handler({ conversation_id: 'target-conv', user_id: 'user-x' });
 
-    // Verify S3 list is scoped to exactly this conversation's prefix
+    // Each listed prefix must be scoped to this conversation and end with /
+    // to avoid matching siblings like conversations/target-conv-2/.
     const listCalls = s3Mock.commandCalls(ListObjectsV2Command);
-    const prefix = listCalls[0].args[0].input.Prefix;
-    expect(prefix).toBe('conversations/target-conv/');
-    // Must end with / to prevent matching conversations/target-conv-2/
-    expect(prefix!.endsWith('/')).toBe(true);
+    expect(listCalls.length).toBe(2);
+    for (const call of listCalls) {
+      const prefix = call.args[0].input.Prefix!;
+      expect(prefix).toContain('target-conv');
+      expect(prefix.endsWith('/')).toBe(true);
+    }
   });
 
   test('EFS deletion targets exact conversation directory, not mount root', async () => {
@@ -155,6 +177,9 @@ describe('Conversation Deletion Lambda', () => {
       })
       .resolvesOnce({
         Contents: [{ Key: 'conversations/conv-2/event1000.json' }],
+      })
+      .resolvesOnce({
+        Contents: [],
       });
 
     s3Mock.on(DeleteObjectsCommand).resolves({});
@@ -169,8 +194,9 @@ describe('Conversation Deletion Lambda', () => {
     const body = JSON.parse(result.body);
     expect(body.s3_objects_deleted).toBe(1001);
 
+    // 2 paginated calls for legacy prefix + 1 call for V1 prefix
     const listCalls = s3Mock.commandCalls(ListObjectsV2Command);
-    expect(listCalls.length).toBe(2);
+    expect(listCalls.length).toBe(3);
   });
 
   test('handles empty S3 bucket gracefully', async () => {

--- a/test/conversation-delete.test.ts
+++ b/test/conversation-delete.test.ts
@@ -85,10 +85,11 @@ describe('Conversation Deletion Lambda', () => {
     expect(prefixes).toContain('users/user-1/v1_conversations/conv-1/');
     expect(listCalls[0].args[0].input.Bucket).toBe('test-data-bucket');
 
-    // Verify S3: deletes happened for both prefixes (Quiet mode)
+    // Verify S3: deletes happened for both prefixes; Quiet=false so per-key
+    // failures (e.g. IAM AccessDenied) are surfaced to the Lambda.
     const deleteCalls = s3Mock.commandCalls(DeleteObjectsCommand);
     expect(deleteCalls.length).toBe(2);
-    expect(deleteCalls[0].args[0].input.Delete?.Quiet).toBe(true);
+    expect(deleteCalls[0].args[0].input.Delete?.Quiet).toBe(false);
 
     // Verify EFS: correct path used (mount + conversation_id, not the mount root)
     expect(fs.rmSync).toHaveBeenCalledTimes(1);
@@ -245,6 +246,29 @@ describe('Conversation Deletion Lambda', () => {
 
     // All storage layers should still be attempted (S3 gracefully handles empty results)
     expect(ddbMock.commandCalls(DeleteItemCommand).length).toBe(1);
+  });
+
+  test('counts only successfully deleted objects when batch returns errors', async () => {
+    // Simulate IAM AccessDenied on one of two objects (e.g. missing perms on
+    // a sub-prefix) — Lambda should NOT count failed keys as deleted.
+    s3Mock.on(ListObjectsV2Command).resolves({
+      Contents: [
+        { Key: 'conversations/conv-err/event1.json' },
+        { Key: 'conversations/conv-err/event2.json' },
+      ],
+    });
+    s3Mock.on(DeleteObjectsCommand).resolves({
+      Errors: [{ Key: 'conversations/conv-err/event2.json', Code: 'AccessDenied', Message: 'denied' }],
+    });
+    rdsMock.on(ExecuteStatementCommand).resolves({});
+    ddbMock.on(DeleteItemCommand).resolves({});
+
+    const result = await handler({ conversation_id: 'conv-err', user_id: 'user-err' });
+    const body = JSON.parse(result.body);
+    // 2 objects each prefix * 2 prefixes = 4 listed; each batch reports 1 error.
+    // Lambda lists both prefixes; here both list resolves return the same 2
+    // objects, with 1 error per batch ⇒ deletedCount = (2-1) + (2-1) = 2.
+    expect(body.s3_objects_deleted).toBe(2);
   });
 
   test('rejects invalid event payload', async () => {


### PR DESCRIPTION
## Summary

Upgrade OpenHands from v1.6.0 → v1.7.0 (released 2026-05-01, 296 commits since 1.6.0).

**v1.7.0 is a major V0→V1 cleanup release**, not a feature release. Upstream deleted multiple V0 packages the fork was patching: `openhands/llm/`, `openhands/utils/llm.py`, `openhands/storage/`, `openhands/core/config/llm_config.py`, and stripped the store-class fields from `openhands/server/config/server_config.py`. SDK bumped v1.15.0 → v1.19.1 (4 minor versions).

## Status: DRAFT — `do-not-merge` label set

The infra-side wiring for v1.7.0 is committed in this PR. Two pieces of dependent work in other repos must complete before this is mergeable:

1. **OpenHands fork branch `custom/v1.7.0-fargate`** must finish cherry-picking the remaining 3 commits and add the new V1 Cognito ports (`openhands/app_server/{settings,secrets,user_auth}/cognito_*.py`). Once that lands and `FORK_REF` is bumped to its final SHA, also re-add those 3 file paths to `docker/download-fork-patches.sh:FILES` (they're documented as TODO comments today).
2. **SDK fork branch** off v1.19.1 with the 5 Bedrock patches (28/29/30/31/32) — currently those patches are applied in-place via `apply-sdk-patches.py` against upstream `OpenHands/software-agent-sdk@v1.19.1`. Optional follow-up: contribute upstream and drop the patches in v1.8.x (see feasibility report §5).

Until those land, this PR's image build will succeed but the container will fail-close at startup (Patch 21 multi-tenant verification refuses to run when V1 Cognito injectors aren't wired in `app_server/config.py`). That's the loud, intended failure mode.

## What's done in this PR

- [x] Feasibility report (`docs/designs/upgrade-v1.7.0-feasibility.md`) — full plan with verified per-patch verdicts and risk register
- [x] `docker/Dockerfile`: `OPENHANDS_VERSION` 1.6.0 → 1.7.0; `openhands-tools` 1.15.0 → 1.19.1; `FORK_REF` repointed to `b707ea5cc1` (partial v1.7.0 fork checkpoint, 17/20 commits ported)
- [x] `docker/agent-server-custom/Dockerfile`: SDK clone pin v1.15.0 → v1.19.1; VS Code stage `1.15.0-python` → `1.19.1-python`
- [x] `docker/agent-server-custom/apply-sdk-patches.py`:
   - **Drop Patch 27** (max_output_tokens cap absorbed in SDK v1.19.1: `llm.py:1273-1287` caps to half the context window when output ≥ context)
   - **Re-anchor Patch 23** (insert before `@field_validator("skills")` since `current_datetime` field was added between `secrets:` and the validator in the v1.19.1 source)
   - **Add Patch 28**: default credential chain in `_list_bedrock_foundation_models` (allows IRSA / IAM-role / `AWS_PROFILE` Bedrock listing without explicit static creds)
   - **Add Patch 29**: cross-region inference profile listing (paginate `list_inference_profiles(typeEquals=SYSTEM_DEFINED)`, surface `bedrock/us.` / `bedrock/eu.` / `bedrock/apac.` / `bedrock/global.` IDs)
   - **Add Patch 30**: cross-region prefix stripping in `get_litellm_model_info` (so `bedrock/us.anthropic.claude-*` finds its `model_cost` entry)
   - **Add Patch 31**: `os.environ.setdefault("AWS_DEFAULT_REGION", …)` alongside `AWS_REGION_NAME` in `_set_env_side_effects` (boto3 prefers the former for some auth modes)
   - **Add Patch 32**: env-hint trigger (`AWS_PROFILE` / `AWS_ROLE_ARN` / `AWS_WEB_IDENTITY_TOKEN_FILE`) for Bedrock listing in `get_supported_llm_models`
- [x] `docker/apply-startup.sh` Patch 21 rewrite — **security-critical**. Was `grep s3_settings_store.S3SettingsStore` on V0 file path; that file is gone in v1.7.0, so the `[ -f ]` guard would silently skip the check. New check fail-closes on `/app/openhands/app_server/config.py` not referencing `CognitoS3SettingsStore` / `CognitoS3SecretsStore` / `CognitoUserAuth`. Container refuses to start until V1 ports are wired.
- [x] `docker/download-fork-patches.sh` — drop V0-deleted entries (server_config.py, secrets.py, llm/bedrock.py, llm/llm.py, llm_config.py, utils/llm.py); add documented TODO for the 3 net-new V1 Cognito port files
- [x] `lib/compute-stack.ts`: `DEFAULT_OPENHANDS_VERSION` → 1.7.0; `DEFAULT_RUNTIME_VERSION` → 1.7-nikolaik; image-digest TODO marker (will be updated after first `docker pull` of v1.7.0 base image)
- [x] Snapshot regen: `test/__snapshots__/stacks.test.ts.snap`
- [x] PR review (`code-reviewer` agent) — both findings addressed: VS Code stage tag mismatch fixed, `FORK_REF` blocking-merge concern → `do-not-merge` label
- [x] Local build passes: `npm run build`
- [x] Local unit tests: 122 passed, 7 pre-existing failures (`UserConfigStack` `PythonFunction` ARM64 Docker bundling — known QEMU/binfmt issue on this dev box, called out in feasibility §A-3)

## Done in earlier sessions of this PR

- Feasibility report committed
- Fork branch `custom/v1.7.0-fargate` pushed at SHA `b707ea5cc1` on `zxkane/OpenHands` (17/20 v1.6.0 fork commits cherry-picked; 3 LLM-targeting commits intentionally skipped because they target V0 files now deleted upstream — those move to SDK-side patches instead)

## TODO before this PR is mergeable

- [ ] **Finish fork branch** `custom/v1.7.0-fargate` (3 remaining cherry-picks + 3 new V1 Cognito port files); update `FORK_REF` and re-add the 3 paths to `download-fork-patches.sh:FILES`
- [ ] **SDK fork branch** off v1.19.1 with the 5 Bedrock patches (alternative: keep applying via `apply-sdk-patches.py` against upstream; the patches are stable as long as the SDK source doesn't shift)
- [ ] **Pull v1.7.0 base image** and update `OPENHANDS_IMAGE_DIGEST` in `lib/compute-stack.ts` + `docker/Dockerfile` (placeholder is the v1.6.0 digest — will fail loudly during Docker build until updated)
- [ ] **Staging deploy** (`./deploy-staging.local.sh`) — requires QEMU binfmt for ARM64
- [ ] **E2E tests** (`./test/select-e2e-tests.sh --all`) — major upgrade
- [ ] **Bedrock-with-IAM-role smoke test** — verifies SDK Bedrock patches (28-32) work end-to-end
- [ ] Multi-tenant isolation E2E (two users, settings/secrets confined to `users/{user_id}/...` paths)

## Test Plan

- [x] Build passes: `npm run build`
- [x] Unit tests pass (122/129; 7 pre-existing ARM64 Docker bundling failures unrelated to v1.7.0)
- [ ] Multi-tenant isolation E2E: two users, settings/secrets confined to `users/{user_id}/...` paths
- [ ] Conversation lifecycle E2E: start, pause, resume, archive
- [ ] Bedrock E2E: IAM-role-only profile (no static keys) lists models and runs a conversation

## Design

- [x] Feasibility report (`docs/designs/upgrade-v1.7.0-feasibility.md`) with verified per-patch verdicts and risk register

## Linked

- Fork branch (partial): https://github.com/zxkane/OpenHands/tree/custom/v1.7.0-fargate
- Upstream v1.7.0 release: https://github.com/OpenHands/OpenHands/releases/tag/1.7.0
