### PR TITLE
fix(agent-server): default LLM model to bedrock/sonnet-4-6 (Patch 33)

### DIFF
--- a/docker/agent-server-custom/.dockerignore
+++ b/docker/agent-server-custom/.dockerignore
@@ -3,3 +3,8 @@
 
 *.md
 README.md
+
+# Python bytecode caches — excluded so test imports of apply-sdk-patches.py
+# don't pollute the Docker build context and shift the asset hash.
+__pycache__/
+*.pyc

--- a/docker/agent-server-custom/apply-sdk-patches.py
+++ b/docker/agent-server-custom/apply-sdk-patches.py
@@ -20,6 +20,11 @@ Patches (active):
               (boto3 prefers AWS_DEFAULT_REGION over AWS_REGION_NAME for some auth modes)
   - Patch 32: Env-hint trigger for Bedrock listing in get_supported_llm_models
               (AWS_PROFILE / AWS_ROLE_ARN / AWS_WEB_IDENTITY_TOKEN_FILE → list Bedrock too)
+  - Patch 33: Change LLM.model Pydantic default from upstream
+              claude-sonnet-4-20250514 (Anthropic direct API) to
+              bedrock/global.anthropic.claude-sonnet-4-6 (Bedrock cross-region
+              inference profile). Prevents fresh conversations from falling
+              back to a model that requires ANTHROPIC_API_KEY.
 
 Removed (absorbed in upstream / obsolete):
   - Patch 24: SDK uses model_dump(mode="json") since v1.15.0
@@ -605,6 +610,56 @@ def patch_31_aws_default_region(build_dir: Path) -> bool:
     return True
 
 
+def patch_33_default_bedrock_model(build_dir: Path) -> bool:
+    """
+    Patch 33: Change the LLM `model` field default from upstream
+    `claude-sonnet-4-20250514` (Anthropic direct API) to
+    `bedrock/global.anthropic.claude-sonnet-4-6` (Bedrock cross-region
+    inference profile).
+
+    Why: when a fresh conversation has no `agent_settings.llm.model`,
+    `_configure_llm` falls back to this Pydantic default. With the upstream
+    value, litellm routes to Anthropic direct, the call fails with no
+    ANTHROPIC_API_KEY, and the bad model string gets frozen into
+    `base_state.json` on EFS — permanently breaking that conversation.
+    """
+    target = build_dir / "openhands-sdk/openhands/sdk/llm/llm.py"
+
+    if not target.exists():
+        print(f"ERROR: Patch 33 - File not found: {target}")
+        return False
+
+    content = target.read_text()
+
+    if 'default="bedrock/global.anthropic.claude-sonnet-4-6"' in content:
+        print("Patch 33: Already applied (skipping)")
+        return True
+
+    # Match precisely on the `model:` Field block so we don't touch the
+    # docstring example or any other occurrence of the upstream string.
+    field_pattern = re.compile(
+        r'(    model: str = Field\(\s*\n\s*)default="claude-sonnet-4-20250514"',
+    )
+    new_content, n = field_pattern.subn(
+        r'\1default="bedrock/global.anthropic.claude-sonnet-4-6"',
+        content,
+        count=1,
+    )
+    if n == 0:
+        print(
+            "ERROR: Patch 33 - Could not find `model` Field default in llm.py; "
+            "SDK structure may have changed"
+        )
+        return False
+
+    target.write_text(new_content)
+    print(
+        "Patch 33: Set LLM.model default to "
+        "bedrock/global.anthropic.claude-sonnet-4-6"
+    )
+    return True
+
+
 def main():
     if len(sys.argv) < 2:
         print(f"Usage: {sys.argv[0]} /path/to/build/directory")
@@ -634,6 +689,7 @@ def main():
     results.append(("Patch 28/29/32", patch_28_29_32_bedrock_listing(build_dir)))
     results.append(("Patch 30", patch_30_model_info_region_prefix(build_dir)))
     results.append(("Patch 31", patch_31_aws_default_region(build_dir)))
+    results.append(("Patch 33", patch_33_default_bedrock_model(build_dir)))
 
     print()
     print("=" * 60)

--- a/docker/test_apply_sdk_patches.py
+++ b/docker/test_apply_sdk_patches.py
@@ -145,7 +145,7 @@ class TestPatch33DefaultBedrockSonnet:
             "patch_30_model_info_region_prefix",
             "patch_31_aws_default_region",
         ):
-            monkeypatch.setattr(module, name, lambda _bd: True)
+            monkeypatch.setattr(module, name, lambda _bd, _n=name: True)
 
         monkeypatch.setattr(sys, "argv", ["apply-sdk-patches.py", str(fake_sdk_tree)])
 

--- a/docker/test_apply_sdk_patches.py
+++ b/docker/test_apply_sdk_patches.py
@@ -1,0 +1,154 @@
+"""
+Unit tests for apply-sdk-patches.py.
+
+These tests verify build-time SDK patches that apply-sdk-patches.py applies to
+the OpenHands SDK source tree before PyInstaller bundles it.
+
+Patch 33 specifically: rewrite the LLM Pydantic model's `model` field default
+from upstream's `claude-sonnet-4-20250514` (Anthropic direct API) to
+`bedrock/global.anthropic.claude-sonnet-4-6` (Bedrock cross-region inference
+profile). Without this patch, a brand-new conversation that has no
+`agent_settings.llm.model` falls back to the SDK default, litellm routes to
+Anthropic direct, and the call fails because no ANTHROPIC_API_KEY is set.
+The bad default also gets frozen into base_state.json on EFS, permanently
+breaking that conversation.
+
+Run with: pytest docker/test_apply_sdk_patches.py -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PATCH_SCRIPT = (
+    REPO_ROOT / "docker" / "agent-server-custom" / "apply-sdk-patches.py"
+)
+
+
+def _load_patch_module():
+    """Load apply-sdk-patches.py as a module despite the hyphenated filename."""
+    spec = importlib.util.spec_from_file_location(
+        "apply_sdk_patches", PATCH_SCRIPT
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["apply_sdk_patches"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def fake_sdk_tree(tmp_path: Path) -> Path:
+    """
+    Build a minimal fake SDK source tree with just the file Patch 33 targets.
+
+    Mirrors the upstream v1.19.1 layout enough for the patch to find its
+    insertion point.
+    """
+    llm_file = tmp_path / "openhands-sdk" / "openhands" / "sdk" / "llm" / "llm.py"
+    llm_file.parent.mkdir(parents=True)
+
+    # A trimmed-down replica of the relevant chunk of upstream
+    # openhands-sdk/openhands/sdk/llm/llm.py (v1.19.1, around line 167).
+    llm_file.write_text(
+        '''"""Stub of upstream LLM model for patch tests."""
+
+from pydantic import BaseModel, Field
+
+
+class LLM(BaseModel):
+    """Trimmed copy of LLM for patch tests."""
+
+    # =========================================================================
+    # Config fields
+    # =========================================================================
+
+    model: str = Field(
+        default="claude-sonnet-4-20250514",
+        description="Model name.",
+    )
+    api_key: str | None = Field(
+        default=None,
+        description="API key.",
+    )
+'''
+    )
+    return tmp_path
+
+
+class TestPatch33DefaultBedrockSonnet:
+    """Patch 33 must rewrite the default value, not just monkey-patch it."""
+
+    def test_patch_changes_default_to_bedrock_sonnet_4_6(
+        self, fake_sdk_tree: Path
+    ) -> None:
+        module = _load_patch_module()
+
+        result = module.patch_33_default_bedrock_model(fake_sdk_tree)
+
+        assert result is True, "patch_33 must report success on a valid tree"
+
+        patched = (
+            fake_sdk_tree
+            / "openhands-sdk"
+            / "openhands"
+            / "sdk"
+            / "llm"
+            / "llm.py"
+        ).read_text()
+
+        assert (
+            'default="bedrock/global.anthropic.claude-sonnet-4-6"' in patched
+        ), "default must be the Bedrock global cross-region inference profile"
+        assert (
+            "claude-sonnet-4-20250514" not in patched
+        ), "old Anthropic-direct default must be removed"
+
+    def test_patch_is_idempotent(self, fake_sdk_tree: Path) -> None:
+        """Re-running the patch on already-patched content must succeed (no-op)."""
+        module = _load_patch_module()
+
+        assert module.patch_33_default_bedrock_model(fake_sdk_tree) is True
+        # Second run hits the "already applied" short-circuit.
+        assert module.patch_33_default_bedrock_model(fake_sdk_tree) is True
+
+    def test_patch_fails_when_target_file_missing(self, tmp_path: Path) -> None:
+        module = _load_patch_module()
+
+        result = module.patch_33_default_bedrock_model(tmp_path)
+
+        assert result is False, "patch_33 must fail loudly if llm.py is absent"
+
+    def test_main_runs_patch_33(self, fake_sdk_tree: Path, monkeypatch) -> None:
+        """main() must include Patch 33 in its results so a failure aborts the build."""
+        module = _load_patch_module()
+
+        called: list[str] = []
+        original = module.patch_33_default_bedrock_model
+
+        def spy(build_dir: Path) -> bool:
+            called.append("patch_33")
+            return original(build_dir)
+
+        monkeypatch.setattr(module, "patch_33_default_bedrock_model", spy)
+        # Stub all other patches to no-ops so we don't need a full SDK tree.
+        for name in (
+            "patch_23_agent_context",
+            "patch_25_json_preprocessing",
+            "patch_26_conversation_state",
+            "patch_28_29_32_bedrock_listing",
+            "patch_30_model_info_region_prefix",
+            "patch_31_aws_default_region",
+        ):
+            monkeypatch.setattr(module, name, lambda _bd: True)
+
+        monkeypatch.setattr(sys, "argv", ["apply-sdk-patches.py", str(fake_sdk_tree)])
+
+        module.main()
+
+        assert "patch_33" in called, "main() must invoke patch_33"

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1397,7 +1397,7 @@ exports[`OpenHands Infrastructure Stacks ComputeStack matches snapshot 1`] = `
               },
               {
                 "Name": "AGENT_SERVER_IMAGE_TAG",
-                "Value": "a2c9b04e494dbdadc4de5c882f10093e1499cde2f3a2ceebe381455f811f3b49",
+                "Value": "2ea4e9218923c719d25e1932b516cbf097f8ce3768fe23263e61845f5a13c72d",
               },
               {
                 "Name": "AGENT_ENABLE_BROWSING",

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1397,7 +1397,7 @@ exports[`OpenHands Infrastructure Stacks ComputeStack matches snapshot 1`] = `
               },
               {
                 "Name": "AGENT_SERVER_IMAGE_TAG",
-                "Value": "6be4e331e1c282f14468f88c021486698f219ac096f08ccab7a60eb0cdd713d8",
+                "Value": "a2c9b04e494dbdadc4de5c882f10093e1499cde2f3a2ceebe381455f811f3b49",
               },
               {
                 "Name": "AGENT_ENABLE_BROWSING",


### PR DESCRIPTION
## Summary

- Add **Patch 33** to `docker/agent-server-custom/apply-sdk-patches.py` that rewrites the LLM Pydantic `model:` field default in upstream `OpenHands/software-agent-sdk@v1.19.1` from `claude-sonnet-4-20250514` (Anthropic direct) to `bedrock/global.anthropic.claude-sonnet-4-6` (the Bedrock cross-region inference profile this deployment already uses).
- Why: when a fresh conversation has no `agent_settings.llm.model`, `_configure_llm` falls back to this Pydantic default. With the upstream value, litellm routes to Anthropic direct, the call fails with no `ANTHROPIC_API_KEY`, and the bad model string gets frozen into `base_state.json` on EFS — permanently breaking that conversation across resumes.
- Discovered during the v1.7.0 upgrade E2E (#81) when an `e2e-*@kane.mx` user with no settings hit the empty-model fallback path.

## Design

No design canvas — minimal, mechanical patch (single regex on a single Field default), consistent with the existing Patch 28-32 style in the same file.

## Test Plan

- [x] **Unit tests added** (`docker/test_apply_sdk_patches.py`, 4 tests, RED-GREEN-REFACTOR followed):
  - `test_patch_changes_default_to_bedrock_sonnet_4_6` — patches a fake SDK tree and verifies the new default
  - `test_patch_is_idempotent` — second run hits the "already applied" short-circuit
  - `test_patch_fails_when_target_file_missing` — fail-loud when `llm.py` is absent
  - `test_main_runs_patch_33` — `main()` includes Patch 33 in `results`, so a future SDK rename surfaces as a hard build failure
- [x] **Verified against real upstream `software-agent-sdk@v1.19.1`** — patch flips only the Field default (line 168), leaves the docstring references on lines 143/155 untouched.
- [x] **Build passes** (`npm run build`)
- [x] **All unit tests pass** locally — 131 TS + 91 Python = 222 tests
- [x] **Snapshot updated** — `AGENT_SERVER_IMAGE_TAG` content hash flipped (deterministic, expected: new patch line changes the docker build context hash)
- [ ] **CI passes** (pending push)
- [ ] **Reviewer bot findings addressed** (pending CI)
- [ ] **E2E test** — staging: delete `e2e-*@kane.mx` user settings → create a new conversation → verify `model` in events is `bedrock/global.anthropic.claude-sonnet-4-6` (not `claude-sonnet-4-20250514`)

## Checklist

- [x] New unit tests cover the new functionality (4 tests, including idempotency + missing-file + main()-wiring)
- [x] Tests written before implementation (TDD RED → GREEN verified)
- [x] Code-simplifier reviewed — no redundancy
- [x] Pre-push code review — Medium findings addressed (idempotency short-circuit added; consistent with Patch 30/31)
- [x] Documentation updated — file header docstring lists Patch 33 alongside the other active patches
- [x] No backwards-compat shims; no broadened scope