### PR TITLE
fix(agent-server): use adaptive thinking for Bedrock Opus 4.7 (Patch 34)

### DIFF
--- a/docker/agent-server-custom/apply-sdk-patches.py
+++ b/docker/agent-server-custom/apply-sdk-patches.py
@@ -25,6 +25,15 @@ Patches (active):
               bedrock/global.anthropic.claude-sonnet-4-6 (Bedrock cross-region
               inference profile). Prevents fresh conversations from falling
               back to a model that requires ANTHROPIC_API_KEY.
+  - Patch 34: Adaptive-thinking support for Claude Opus 4.7 family on Bedrock.
+              Opus 4.7 (and Mythos Preview) only accept thinking.type="adaptive";
+              Bedrock returns 400 for thinking.type="enabled" with budget_tokens.
+              Without this patch, litellm's bedrock translator converts
+              reasoning_effort="high" → thinking={"type":"enabled",...}, which
+              the model rejects. The patch rewrites those parameters into
+              {"thinking":{"type":"adaptive"}, "output_config":{"effort":...}}
+              for matching models. Tracks upstream litellm issues #25957,
+              #27168, #26334.
 
 Removed (absorbed in upstream / obsolete):
   - Patch 24: SDK uses model_dump(mode="json") since v1.15.0
@@ -660,6 +669,110 @@ def patch_33_default_bedrock_model(build_dir: Path) -> bool:
     return True
 
 
+def patch_34_opus_47_adaptive_thinking(build_dir: Path) -> bool:
+    """
+    Patch 34: Adaptive thinking for Claude Opus 4.7 family on Bedrock.
+
+    Why: Bedrock's Anthropic Claude Opus 4.7 (and Mythos Preview) only support
+    `thinking.type = "adaptive"`. They return HTTP 400 for the legacy
+    `thinking.type = "enabled"` shape with `budget_tokens`.
+
+    The bug chain without this patch:
+      1. SDK sees `LLM.reasoning_effort = "high"` and forwards it because
+         litellm reports `reasoning_effort` is supported for `claude-opus-4*`
+         (model_features._supports_reasoning_effort delegates to litellm).
+      2. litellm's bedrock converse translator (`_handle_reasoning_effort_parameter`)
+         converts `reasoning_effort` → `thinking = {"type":"enabled",...}` via
+         `AnthropicConfig._map_reasoning_effort` for any non-Nova/non-GPT-OSS
+         model. There is no Opus 4.7 awareness upstream
+         (litellm issues #25957, #27168, #26334).
+      3. Bedrock rejects the request: "thinking.type.enabled is not supported
+         for this model. Use thinking.type.adaptive ...".
+
+    The fix: in `select_chat_options`, after all existing rules run, detect
+    Opus-4.7-family models and rewrite the kwargs:
+      - drop `reasoning_effort` (so litellm does not generate `thinking.enabled`)
+      - drop any pre-existing `thinking` entry (e.g. from extended-thinking path)
+      - inject `thinking = {"type": "adaptive"}` (passed through litellm
+        line `if param == "thinking": optional_params["thinking"] = value`)
+      - inject top-level `output_config = {"effort": <effort>}` which litellm
+        does not recognize as a converse param and therefore forwards into
+        Bedrock's `additionalModelRequestFields` — exactly where the API
+        expects it (per AWS docs on adaptive thinking).
+      - drop the `interleaved-thinking-2025-05-14` beta header — adaptive
+        thinking enables interleaved thinking implicitly and the legacy header
+        is unnecessary.
+
+    Models matched by substring (case-insensitive): "claude-opus-4-7",
+    "claude-mythos-preview". Bedrock prefixes like
+    `bedrock/global.anthropic.claude-opus-4-7` are matched.
+
+    This is a stop-gap pending upstream litellm support for adaptive thinking.
+    """
+    target = build_dir / "openhands-sdk/openhands/sdk/llm/options/chat_options.py"
+
+    if not target.exists():
+        print(f"ERROR: Patch 34 - File not found: {target}")
+        return False
+
+    content = target.read_text()
+
+    if "OPUS_47_ADAPTIVE_THINKING_MODELS" in content:
+        print("Patch 34: Already applied (skipping)")
+        return True
+
+    # Insert the rewrite block immediately before `return out`.
+    anchor = "    return out\n"
+    if content.count(anchor) != 1:
+        print(
+            "ERROR: Patch 34 - Expected exactly one 'return out' anchor in "
+            "chat_options.py; SDK structure may have changed"
+        )
+        return False
+
+    patch_block = '''\
+    # Patch 34 (openhands-infra): adaptive thinking for Claude Opus 4.7 family.
+    # Bedrock's Opus 4.7 only accepts thinking.type="adaptive"; the legacy
+    # enabled+budget_tokens shape returns HTTP 400. litellm's bedrock translator
+    # currently converts reasoning_effort -> thinking.enabled for any
+    # claude-opus-4* model. Rewrite the kwargs here so the request is shaped
+    # correctly. See docker/agent-server-custom/apply-sdk-patches.py.
+    OPUS_47_ADAPTIVE_THINKING_MODELS = [
+        "claude-opus-4-7",
+        "claude-mythos-preview",
+    ]
+    _model_lower = (llm.model or "").lower()
+    if any(token in _model_lower for token in OPUS_47_ADAPTIVE_THINKING_MODELS):
+        effort = out.pop("reasoning_effort", None)
+        if effort is None:
+            effort = llm.reasoning_effort
+        out.pop("thinking", None)
+        out["thinking"] = {"type": "adaptive"}
+        if effort and effort != "none":
+            out["output_config"] = {"effort": effort}
+        # Adaptive thinking enables interleaved thinking implicitly; the legacy
+        # beta header is unnecessary and Bedrock ignores it.
+        headers = out.get("extra_headers")
+        if isinstance(headers, dict):
+            headers.pop("anthropic-beta", None)
+            if not headers:
+                out.pop("extra_headers", None)
+        # Anthropic thinking models ignore temp/top_p — keep behavior consistent
+        # with the extended-thinking branch above.
+        out.pop("temperature", None)
+        out.pop("top_p", None)
+
+'''
+
+    new_content = content.replace(anchor, patch_block + anchor, 1)
+    target.write_text(new_content)
+    print(
+        "Patch 34: Added Opus 4.7 adaptive-thinking rewrite to "
+        "select_chat_options"
+    )
+    return True
+
+
 def main():
     if len(sys.argv) < 2:
         print(f"Usage: {sys.argv[0]} /path/to/build/directory")
@@ -690,6 +803,7 @@ def main():
     results.append(("Patch 30", patch_30_model_info_region_prefix(build_dir)))
     results.append(("Patch 31", patch_31_aws_default_region(build_dir)))
     results.append(("Patch 33", patch_33_default_bedrock_model(build_dir)))
+    results.append(("Patch 34", patch_34_opus_47_adaptive_thinking(build_dir)))
 
     print()
     print("=" * 60)

--- a/docker/test_apply_sdk_patches.py
+++ b/docker/test_apply_sdk_patches.py
@@ -4,14 +4,20 @@ Unit tests for apply-sdk-patches.py.
 These tests verify build-time SDK patches that apply-sdk-patches.py applies to
 the OpenHands SDK source tree before PyInstaller bundles it.
 
-Patch 33 specifically: rewrite the LLM Pydantic model's `model` field default
-from upstream's `claude-sonnet-4-20250514` (Anthropic direct API) to
+Patch 33: rewrite the LLM Pydantic model's `model` field default from
+upstream's `claude-sonnet-4-20250514` (Anthropic direct API) to
 `bedrock/global.anthropic.claude-sonnet-4-6` (Bedrock cross-region inference
 profile). Without this patch, a brand-new conversation that has no
 `agent_settings.llm.model` falls back to the SDK default, litellm routes to
 Anthropic direct, and the call fails because no ANTHROPIC_API_KEY is set.
 The bad default also gets frozen into base_state.json on EFS, permanently
 breaking that conversation.
+
+Patch 34: rewrite chat-options kwargs for Claude Opus 4.7 family so the
+Bedrock request uses adaptive thinking. Bedrock returns HTTP 400 for the
+legacy `thinking.type="enabled"` shape on Opus 4.7; only `"adaptive"` is
+accepted. Upstream litellm still translates `reasoning_effort` to
+`thinking={"type":"enabled",...}` for any `claude-opus-4*` model.
 
 Run with: pytest docker/test_apply_sdk_patches.py -v
 """
@@ -144,6 +150,7 @@ class TestPatch33DefaultBedrockSonnet:
             "patch_28_29_32_bedrock_listing",
             "patch_30_model_info_region_prefix",
             "patch_31_aws_default_region",
+            "patch_34_opus_47_adaptive_thinking",
         ):
             monkeypatch.setattr(module, name, lambda _bd, _n=name: True)
 
@@ -152,3 +159,374 @@ class TestPatch33DefaultBedrockSonnet:
         module.main()
 
         assert "patch_33" in called, "main() must invoke patch_33"
+
+
+# ---------------------------------------------------------------------------
+# Patch 34: Opus 4.7 adaptive-thinking rewrite in chat_options.py
+# ---------------------------------------------------------------------------
+
+
+# Trimmed copy of upstream openhands-sdk/openhands/sdk/llm/options/chat_options.py
+# (SDK v1.19.1). The patch's anchor is the `return out` line; everything above
+# stays as-is.
+_CHAT_OPTIONS_STUB = '''from __future__ import annotations
+
+from typing import Any
+
+from openhands.sdk.llm.options.common import apply_defaults_if_absent
+from openhands.sdk.llm.utils.model_features import get_features
+
+
+def select_chat_options(
+    llm, user_kwargs: dict[str, Any], has_tools: bool
+) -> dict[str, Any]:
+    """Behavior-preserving extraction of _normalize_call_kwargs."""
+    defaults: dict[str, Any] = {
+        "top_k": llm.top_k,
+        "top_p": llm.top_p,
+        "temperature": llm.temperature,
+        "max_completion_tokens": llm.max_output_tokens,
+    }
+    out = apply_defaults_if_absent(user_kwargs, defaults)
+
+    # If user didn't set extra_headers, propagate from llm config
+    if llm.extra_headers is not None and "extra_headers" not in out:
+        out["extra_headers"] = dict(llm.extra_headers)
+
+    supports_reasoning_effort = get_features(llm.model).supports_reasoning_effort
+    if supports_reasoning_effort:
+        if llm.reasoning_effort is not None:
+            out["reasoning_effort"] = llm.reasoning_effort
+        if "gemini" not in llm.model.lower():
+            out.pop("temperature", None)
+            out.pop("top_p", None)
+
+    if get_features(llm.model).supports_extended_thinking:
+        if llm.extended_thinking_budget:
+            budget_tokens = min(llm.extended_thinking_budget, llm.max_output_tokens - 1)
+            out["thinking"] = {
+                "type": "enabled",
+                "budget_tokens": budget_tokens,
+            }
+            existing = out.get("extra_headers") or {}
+            out["extra_headers"] = {
+                "anthropic-beta": "interleaved-thinking-2025-05-14",
+                **existing,
+            }
+            out["max_tokens"] = llm.max_output_tokens
+        out.pop("temperature", None)
+        out.pop("top_p", None)
+
+    return out
+'''
+
+
+# Stub source for openhands.sdk.llm.options.common — written to disk so the
+# real module loader resolves it without needing the OpenHands SDK install.
+_COMMON_STUB = '''def apply_defaults_if_absent(user_kwargs, defaults):
+    out = dict(user_kwargs) if user_kwargs else {}
+    for k, v in defaults.items():
+        if v is not None and k not in out:
+            out[k] = v
+    return out
+'''
+
+
+# Stub source for openhands.sdk.llm.utils.model_features — drives just enough
+# behavior for select_chat_options to take each Anthropic branch.
+_MODEL_FEATURES_STUB = '''from dataclasses import dataclass
+
+
+@dataclass
+class _F:
+    supports_reasoning_effort: bool = False
+    supports_extended_thinking: bool = False
+    supports_prompt_cache: bool = False
+    supports_stop_words: bool = True
+    supports_responses_api: bool = False
+    force_string_serializer: bool = False
+    send_reasoning_content: bool = False
+    supports_prompt_cache_retention: bool = False
+
+
+def get_features(model):
+    m = (model or "").lower()
+    if "claude-opus-4-7" in m or "mythos-preview" in m:
+        return _F(supports_reasoning_effort=True)
+    if "claude-sonnet-4-6" in m or "claude-sonnet-4-5" in m:
+        return _F(
+            supports_reasoning_effort=True,
+            supports_extended_thinking=True,
+        )
+    return _F()
+'''
+
+
+@pytest.fixture
+def fake_chat_options_tree(tmp_path: Path) -> Path:
+    """Build a minimal SDK tree with chat_options.py + dependency stubs."""
+    sdk_root = tmp_path / "openhands-sdk" / "openhands" / "sdk"
+    options_dir = sdk_root / "llm" / "options"
+    utils_dir = sdk_root / "llm" / "utils"
+    options_dir.mkdir(parents=True)
+    utils_dir.mkdir(parents=True)
+
+    # Init files so importlib treats these as packages
+    for pkg_dir in (
+        sdk_root.parent,
+        sdk_root,
+        sdk_root / "llm",
+        options_dir,
+        utils_dir,
+    ):
+        (pkg_dir / "__init__.py").write_text("")
+
+    (options_dir / "chat_options.py").write_text(_CHAT_OPTIONS_STUB)
+    (options_dir / "common.py").write_text(_COMMON_STUB)
+    (utils_dir / "model_features.py").write_text(_MODEL_FEATURES_STUB)
+    return tmp_path
+
+
+def _load_patched_select_chat_options(build_dir: Path):
+    """
+    Import the patched chat_options.py from build_dir using importlib.
+
+    Uses spec_from_file_location with explicit submodule_search_locations so
+    the patched chat_options.py and its sibling stub modules resolve without
+    polluting sys.modules with `openhands.*` entries that other tests rely on.
+    """
+    base = build_dir / "openhands-sdk" / "openhands" / "sdk" / "llm"
+
+    # Load common.py and model_features.py under unique synthetic names so we
+    # don't clobber any real openhands.sdk.* modules already in sys.modules.
+    common_spec = importlib.util.spec_from_file_location(
+        "_patch34_test_common", base / "options" / "common.py"
+    )
+    common_mod = importlib.util.module_from_spec(common_spec)
+    common_spec.loader.exec_module(common_mod)
+
+    features_spec = importlib.util.spec_from_file_location(
+        "_patch34_test_model_features", base / "utils" / "model_features.py"
+    )
+    features_mod = importlib.util.module_from_spec(features_spec)
+    features_spec.loader.exec_module(features_mod)
+
+    # Insert under the names chat_options.py imports from, but save and restore
+    # any pre-existing entries to keep this test isolated.
+    sentinel = object()
+    saved = {
+        "openhands.sdk.llm.options.common": sys.modules.get(
+            "openhands.sdk.llm.options.common", sentinel
+        ),
+        "openhands.sdk.llm.utils.model_features": sys.modules.get(
+            "openhands.sdk.llm.utils.model_features", sentinel
+        ),
+    }
+    sys.modules["openhands.sdk.llm.options.common"] = common_mod
+    sys.modules["openhands.sdk.llm.utils.model_features"] = features_mod
+    try:
+        chat_spec = importlib.util.spec_from_file_location(
+            "_patch34_test_chat_options", base / "options" / "chat_options.py"
+        )
+        chat_mod = importlib.util.module_from_spec(chat_spec)
+        chat_spec.loader.exec_module(chat_mod)
+        return chat_mod.select_chat_options
+    finally:
+        for key, prev in saved.items():
+            if prev is sentinel:
+                sys.modules.pop(key, None)
+            else:
+                sys.modules[key] = prev
+
+
+class _FakeLLM:
+    """Minimal stand-in for the SDK LLM model used by select_chat_options."""
+
+    def __init__(self, model: str, **overrides) -> None:
+        self.model = model
+        self.top_k = None
+        self.top_p = 0.95
+        self.temperature = 0.0
+        self.max_output_tokens = 16000
+        self.reasoning_effort = "high"
+        self.extended_thinking_budget = 200_000
+        self.extra_headers = None
+        for k, v in overrides.items():
+            setattr(self, k, v)
+
+
+class TestPatch34Opus47AdaptiveThinking:
+    """Patch 34 must rewrite kwargs into the Bedrock-required adaptive shape."""
+
+    def test_patch_inserts_rewrite_block(
+        self, fake_chat_options_tree: Path
+    ) -> None:
+        module = _load_patch_module()
+
+        result = module.patch_34_opus_47_adaptive_thinking(fake_chat_options_tree)
+
+        assert result is True
+        patched = (
+            fake_chat_options_tree
+            / "openhands-sdk"
+            / "openhands"
+            / "sdk"
+            / "llm"
+            / "options"
+            / "chat_options.py"
+        ).read_text()
+
+        assert "OPUS_47_ADAPTIVE_THINKING_MODELS" in patched
+        assert '"claude-opus-4-7"' in patched
+        assert '"claude-mythos-preview"' in patched
+        assert '"adaptive"' in patched
+
+    def test_patch_is_idempotent(self, fake_chat_options_tree: Path) -> None:
+        module = _load_patch_module()
+        assert module.patch_34_opus_47_adaptive_thinking(fake_chat_options_tree) is True
+        assert module.patch_34_opus_47_adaptive_thinking(fake_chat_options_tree) is True
+
+    def test_patch_fails_when_target_file_missing(self, tmp_path: Path) -> None:
+        module = _load_patch_module()
+        assert module.patch_34_opus_47_adaptive_thinking(tmp_path) is False
+
+    def test_opus_4_7_emits_adaptive_thinking_and_strips_reasoning_effort(
+        self, fake_chat_options_tree: Path
+    ) -> None:
+        """Core fix: Opus 4.7 must NOT carry thinking.type=enabled or reasoning_effort."""
+        module = _load_patch_module()
+        assert module.patch_34_opus_47_adaptive_thinking(fake_chat_options_tree) is True
+
+        select = _load_patched_select_chat_options(fake_chat_options_tree)
+        llm = _FakeLLM("bedrock/global.anthropic.claude-opus-4-7")
+
+        out = select(llm, {}, has_tools=False)
+
+        assert out.get("thinking") == {"type": "adaptive"}
+        assert "reasoning_effort" not in out, (
+            "reasoning_effort must be stripped so litellm doesn't translate "
+            "it into thinking.type=enabled"
+        )
+        assert out.get("output_config") == {"effort": "high"}
+        assert "temperature" not in out
+        assert "top_p" not in out
+
+    def test_mythos_preview_also_uses_adaptive(
+        self, fake_chat_options_tree: Path
+    ) -> None:
+        module = _load_patch_module()
+        assert module.patch_34_opus_47_adaptive_thinking(fake_chat_options_tree) is True
+
+        select = _load_patched_select_chat_options(fake_chat_options_tree)
+        llm = _FakeLLM("bedrock/anthropic.claude-mythos-preview")
+
+        out = select(llm, {}, has_tools=False)
+        assert out.get("thinking") == {"type": "adaptive"}
+
+    def test_effort_none_omits_output_config(
+        self, fake_chat_options_tree: Path
+    ) -> None:
+        module = _load_patch_module()
+        assert module.patch_34_opus_47_adaptive_thinking(fake_chat_options_tree) is True
+
+        select = _load_patched_select_chat_options(fake_chat_options_tree)
+        llm = _FakeLLM(
+            "bedrock/global.anthropic.claude-opus-4-7", reasoning_effort="none"
+        )
+
+        out = select(llm, {}, has_tools=False)
+        assert out.get("thinking") == {"type": "adaptive"}
+        assert "output_config" not in out
+
+    def test_legacy_anthropic_beta_header_stripped(
+        self, fake_chat_options_tree: Path
+    ) -> None:
+        """Adaptive thinking enables interleaved thinking implicitly."""
+        module = _load_patch_module()
+        assert module.patch_34_opus_47_adaptive_thinking(fake_chat_options_tree) is True
+
+        select = _load_patched_select_chat_options(fake_chat_options_tree)
+        llm = _FakeLLM(
+            "bedrock/global.anthropic.claude-opus-4-7",
+            extra_headers={
+                "anthropic-beta": "interleaved-thinking-2025-05-14",
+                "X-Custom": "keep-me",
+            },
+        )
+
+        out = select(llm, {}, has_tools=False)
+        assert out.get("extra_headers") == {"X-Custom": "keep-me"}
+
+    def test_only_legacy_beta_header_removes_dict_entirely(
+        self, fake_chat_options_tree: Path
+    ) -> None:
+        module = _load_patch_module()
+        assert module.patch_34_opus_47_adaptive_thinking(fake_chat_options_tree) is True
+
+        select = _load_patched_select_chat_options(fake_chat_options_tree)
+        llm = _FakeLLM(
+            "bedrock/global.anthropic.claude-opus-4-7",
+            extra_headers={"anthropic-beta": "interleaved-thinking-2025-05-14"},
+        )
+
+        out = select(llm, {}, has_tools=False)
+        assert "extra_headers" not in out
+
+    def test_case_insensitive_model_match(
+        self, fake_chat_options_tree: Path
+    ) -> None:
+        module = _load_patch_module()
+        assert module.patch_34_opus_47_adaptive_thinking(fake_chat_options_tree) is True
+
+        select = _load_patched_select_chat_options(fake_chat_options_tree)
+        llm = _FakeLLM("Bedrock/Global.Anthropic.CLAUDE-OPUS-4-7")
+
+        out = select(llm, {}, has_tools=False)
+        assert out.get("thinking") == {"type": "adaptive"}
+
+    def test_sonnet_4_6_still_uses_extended_thinking(
+        self, fake_chat_options_tree: Path
+    ) -> None:
+        """Patch 34 must NOT regress sonnet-4-6, which is currently working."""
+        module = _load_patch_module()
+        assert module.patch_34_opus_47_adaptive_thinking(fake_chat_options_tree) is True
+
+        select = _load_patched_select_chat_options(fake_chat_options_tree)
+        llm = _FakeLLM("bedrock/global.anthropic.claude-sonnet-4-6")
+
+        out = select(llm, {}, has_tools=False)
+        assert out.get("thinking", {}).get("type") == "enabled"
+        assert "output_config" not in out
+
+    def test_main_runs_patch_34(
+        self, fake_chat_options_tree: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """main() must include patch_34 so a failure aborts the build."""
+        module = _load_patch_module()
+
+        called: list[str] = []
+        original = module.patch_34_opus_47_adaptive_thinking
+
+        def spy(build_dir: Path) -> bool:
+            called.append("patch_34")
+            return original(build_dir)
+
+        monkeypatch.setattr(module, "patch_34_opus_47_adaptive_thinking", spy)
+        for name in (
+            "patch_23_agent_context",
+            "patch_25_json_preprocessing",
+            "patch_26_conversation_state",
+            "patch_28_29_32_bedrock_listing",
+            "patch_30_model_info_region_prefix",
+            "patch_31_aws_default_region",
+            "patch_33_default_bedrock_model",
+        ):
+            monkeypatch.setattr(module, name, lambda _bd, _n=name: True)
+
+        monkeypatch.setattr(
+            sys, "argv", ["apply-sdk-patches.py", str(fake_chat_options_tree)]
+        )
+
+        module.main()
+
+        assert "patch_34" in called, "main() must invoke patch_34"

--- a/test/E2E_TEST_CASES.md
+++ b/test/E2E_TEST_CASES.md
@@ -3980,3 +3980,206 @@ mcp__chrome-devtools__evaluate_script({
 - Without the fix, the Changes tab showed empty for connected repos because it queried the outer
   `/workspace` repo instead of the nested cloned repo at `/workspace/project/<repo>/`
 - The fix is covered by 19 unit regression tests in `docker/test_patch_fix_git_paths.js`
+
+---
+
+## TC-035: Verify Claude Adaptive-Thinking Models on Bedrock
+
+### Description
+Verify that Claude models which **only** support `thinking.type="adaptive"` (Opus 4.7, Mythos
+Preview) work end-to-end on Bedrock. These models reject the legacy
+`thinking.type="enabled"` shape with HTTP 400 — yet the SDK / litellm pipeline still emits
+that legacy shape for any `claude-opus-4*` model unless `apply-sdk-patches.py:patch_34` is
+applied.
+
+**Bug scenario** (the gap that allowed this through PR #81):
+
+1. User defaults set `reasoning_effort="high"` and `extended_thinking_budget=200000`.
+2. SDK `model_features._supports_reasoning_effort` delegates to litellm, which says
+   `claude-opus-4-7` supports `reasoning_effort` (it matches the `claude-opus-4*` substring).
+3. SDK forwards `out["reasoning_effort"]="high"` to litellm.
+4. litellm's bedrock converse translator rewrites it via
+   `AnthropicConfig._map_reasoning_effort` into
+   `thinking={"type":"enabled","budget_tokens":...}` — Bedrock rejects the request:
+   ```
+   BedrockException - "thinking.type.enabled" is not supported for this model.
+   Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.
+   ```
+5. Existing E2E coverage stops at Sonnet 4.6 (default) and Haiku 4.5 (TC-023 §4) — both
+   accept the legacy shape, so neither catches the regression.
+
+**Fix**: SDK Patch 34 (`apply-sdk-patches.py:patch_34_opus_47_adaptive_thinking`) detects
+the Opus 4.7 family in `select_chat_options` and rewrites kwargs to
+`thinking={"type":"adaptive"}` + top-level `output_config={"effort": <effort>}`.
+
+### Category
+Compute / agent-server changes (triggered by changes to
+`docker/agent-server-custom/apply-sdk-patches.py`,
+`docker/agent-server-custom/Dockerfile`, or anything that rebuilds the agent-server image).
+
+### Prerequisites
+- TC-003 completed (logged in)
+- Sandbox stack deployed with the Patch 34 build of agent-server-custom
+- Bedrock Claude Opus 4.7 cross-region inference profile is callable from the agent-server
+  IAM role in the deploy region
+
+### Models Under Test
+| Model ID | Family | Why it's in this test |
+|---|---|---|
+| `bedrock/global.anthropic.claude-opus-4-7` | Opus 4.7 | Adaptive-only; fails without Patch 34 |
+| `bedrock/global.anthropic.claude-mythos-preview` | Mythos | Adaptive-only; same code path |
+
+> When Anthropic ships future adaptive-only models, append them to this list and rerun.
+
+### Steps
+
+For **each model in the list above**, repeat steps 1–6:
+
+1. Switch the user's model via the settings API
+   ```javascript
+   mcp__chrome-devtools__evaluate_script({
+     function: `async () => {
+       const r = await fetch('/api/settings', {
+         method: 'POST',
+         headers: { 'Content-Type': 'application/json' },
+         body: JSON.stringify({ llm_model: '<MODEL_ID_UNDER_TEST>' })
+       });
+       const s = await fetch('/api/settings').then(x => x.json());
+       return { status: r.status, llm_model: s.llm_model };
+     }`
+   })
+   // Expected: { status: 200, llm_model: '<MODEL_ID_UNDER_TEST>' }
+   ```
+
+2. Capture the start time as a millisecond epoch in your **shell** (not the
+   browser) — CloudWatch's `--start-time` flag wants ms-since-epoch, and
+   doing it shell-side keeps the value portable across macOS / Linux.
+   ```bash
+   # Run in the same shell you'll use for step 5 / step 6.
+   TEST_START_MS=$(($(date +%s) * 1000))
+   echo "$TEST_START_MS"
+   ```
+
+3. Start a new conversation
+   ```javascript
+   mcp__chrome-devtools__navigate_page({ url: "https://${FULL_DOMAIN}", type: "url" })
+   mcp__chrome-devtools__wait_for({ text: "New Conversation", timeout: 10000 })
+   mcp__chrome-devtools__click({ uid: "<new-conversation-button>" })
+   mcp__chrome-devtools__wait_for({ text: "What do you want", timeout: 120000 })
+   // Record CONV_ID from URL: /conversations/<CONV_ID>
+   ```
+
+4. Send a prompt that forces a real Bedrock call (cannot be answered from cache)
+   ```javascript
+   mcp__chrome-devtools__fill({
+     uid: "<chat-input>",
+     value: "What is 2+2? Reply with just the number."
+   })
+   mcp__chrome-devtools__press_key({ key: "Enter" })
+   // Wait for the agent to respond — the failure mode of this bug is
+   // either (a) an explicit Bedrock error bubble in the chat, or
+   //        (b) the agent silently retrying then giving up.
+   mcp__chrome-devtools__wait_for({ text: "4", timeout: 90000 })
+   ```
+
+5. **Critical**: Verify the sandbox agent-server logs contain **no** Bedrock
+   thinking-type rejection for this conversation. The sandbox container is
+   what calls Bedrock, so the rejection lands in `/openhands/sandbox`
+   (declared in `lib/sandbox-stack.ts:294`) — *not* the app-server log
+   group.
+   ```bash
+   # Run from a shell with AWS creds for the deploy region.
+   # TEST_START_MS is from step 2. Adjust --region for production.
+   aws logs filter-log-events \
+     --log-group-name /openhands/sandbox \
+     --region us-west-2 \
+     --start-time "$TEST_START_MS" \
+     --filter-pattern '"thinking.type.enabled"' \
+     --query 'events[*].message' --output text
+   # Expected: empty output
+
+   aws logs filter-log-events \
+     --log-group-name /openhands/sandbox \
+     --region us-west-2 \
+     --start-time "$TEST_START_MS" \
+     --filter-pattern 'BedrockException' \
+     --query 'events[*].message' --output text
+   # Expected: empty output
+   ```
+
+   > **Why this is the load-bearing assertion**: OpenHands retries on
+   > `litellm.BadRequestError`, so step 4 ("agent answers correctly") can
+   > pass even when *every* Bedrock call fails — the user just sees a
+   > longer pause. The CloudWatch filter is the only signal that confirms
+   > the Bedrock call actually succeeded on the first attempt with the
+   > right shape. If you query the wrong log group, the filter returns
+   > empty vacuously and the assertion gives false confidence.
+
+6. (Optional) Verify the request actually reached Bedrock with the adaptive
+   shape — only meaningful when `LITELLM_LOG=DEBUG` is enabled in the
+   sandbox container env.
+   ```bash
+   aws logs filter-log-events \
+     --log-group-name /openhands/sandbox \
+     --region us-west-2 \
+     --start-time "$TEST_START_MS" \
+     --filter-pattern '"\"thinking\": {\"type\": \"adaptive\"}"' \
+     --query 'events[*].message' --output text
+   # Expected (when DEBUG logs are on): at least one match showing
+   #   thinking={"type":"adaptive"} and output_config={"effort":"high"}
+   # Skip this assertion if DEBUG logs are not enabled — steps 4–5 are sufficient.
+   ```
+
+After all models pass, **restore the default**:
+   ```javascript
+   mcp__chrome-devtools__evaluate_script({
+     function: `async () => {
+       await fetch('/api/settings', {
+         method: 'POST',
+         headers: { 'Content-Type': 'application/json' },
+         body: JSON.stringify({ llm_model: 'bedrock/global.anthropic.claude-sonnet-4-6' })
+       });
+       return 'restored';
+     }`
+   })
+   ```
+
+### Acceptance Criteria
+
+| # | Criteria | Verification |
+|---|----------|--------------|
+| 1 | Model switch persists | `GET /api/settings` returns the model under test |
+| 2 | New conversation starts | Status reaches "What do you want to build?" within 120s |
+| 3 | Agent answers correctly | Response contains "4" for the `2+2` prompt within 90s |
+| 4 | **No `thinking.type.enabled` in `/openhands/sandbox`** | First `filter-log-events` query in step 5 returns empty |
+| 5 | **No `BedrockException` in `/openhands/sandbox`** | Second `filter-log-events` query in step 5 returns empty |
+| 6 | (Optional) Adaptive shape in DEBUG logs | Step 6 returns at least one match when `LITELLM_LOG=DEBUG` |
+| 7 | Default model restored | Final `/api/settings` shows `bedrock/global.anthropic.claude-sonnet-4-6` |
+
+### When to Run This Test
+
+**Run TC-035 whenever any of these change:**
+- `docker/agent-server-custom/apply-sdk-patches.py` (especially patches touching
+  `chat_options.py`, `model_features.py`, or anything around `reasoning_effort` /
+  `thinking`)
+- `docker/agent-server-custom/Dockerfile` (`SDK_VERSION` bump → re-verify Patch 34
+  anchors still match)
+- The OpenHands SDK version pinned in the Dockerfile changes
+- The litellm version transitively pulled in via `uv sync` changes
+
+**Skip TC-035 only when**: the deploy is config-only (no agent-server image rebuild) and
+the existing image already contains a verified Patch 34 build.
+
+### Notes
+
+- Patch 34's unit tests (`docker/test_apply_sdk_patches.py::TestPatch34Opus47AdaptiveThinking`)
+  cover the build-time rewrite contract — TC-035 is the runtime end-to-end check that the
+  rewritten kwargs survive litellm + reach Bedrock correctly.
+- This test is intentionally generic ("Claude adaptive-thinking models") so the same case
+  covers Mythos Preview today and any future adaptive-only models without rewriting the
+  test case. Just append the new model ID to the table above.
+- Tracks upstream litellm issues
+  [#25957](https://github.com/BerriAI/litellm/issues/25957),
+  [#27168](https://github.com/BerriAI/litellm/issues/27168),
+  [#26334](https://github.com/BerriAI/litellm/issues/26334) — when those land, revisit
+  Patch 34 and decide whether to drop the patch in favor of upstream litellm support.

--- a/test/__snapshots__/stacks.test.ts.snap
+++ b/test/__snapshots__/stacks.test.ts.snap
@@ -1397,7 +1397,7 @@ exports[`OpenHands Infrastructure Stacks ComputeStack matches snapshot 1`] = `
               },
               {
                 "Name": "AGENT_SERVER_IMAGE_TAG",
-                "Value": "2ea4e9218923c719d25e1932b516cbf097f8ce3768fe23263e61845f5a13c72d",
+                "Value": "f1edd0c7a28a480509e915d3588ffaf83cd855f4c7f5072065c09f57ab827096",
               },
               {
                 "Name": "AGENT_ENABLE_BROWSING",

--- a/test/select-e2e-tests.sh
+++ b/test/select-e2e-tests.sh
@@ -79,6 +79,14 @@ LIFECYCLE_TESTS=(
     "TC-029:Conversation Deletion"
 )
 
+# LLM / Bedrock model-routing tests — required whenever the agent-server SDK
+# patches or anything that affects the LLM call shape changes. TC-035 guards
+# against regressions in the chat_options.py rewrite (e.g., Patch 34 for
+# Opus 4.7 adaptive thinking).
+LLM_BEDROCK_TESTS=(
+    "TC-035:Claude Adaptive-Thinking Models on Bedrock"
+)
+
 # Detect change categories
 HAS_AUTH_CHANGES=false
 HAS_RUNTIME_CHANGES=false
@@ -87,6 +95,7 @@ HAS_SANDBOX_AWS_CHANGES=false
 HAS_MCP_CHANGES=false
 HAS_USER_CONFIG_CHANGES=false
 HAS_LIFECYCLE_CHANGES=false
+HAS_LLM_BEDROCK_CHANGES=false
 
 # --all flag: select every test category
 if $RUN_ALL; then
@@ -97,6 +106,7 @@ if $RUN_ALL; then
     HAS_MCP_CHANGES=true
     HAS_USER_CONFIG_CHANGES=true
     HAS_LIFECYCLE_CHANGES=true
+    HAS_LLM_BEDROCK_CHANGES=true
 fi
 
 for file in $CHANGED_FILES; do
@@ -133,6 +143,14 @@ for file in $CHANGED_FILES; do
     # Conversation lifecycle changes (archival, deletion)
     if [[ "$file" =~ lambda/conversation-archival/ ]] || [[ "$file" =~ lambda/conversation-delete/ ]] || [[ "$file" =~ conversationRetention ]]; then
         HAS_LIFECYCLE_CHANGES=true
+    fi
+
+    # LLM / Bedrock call-shape changes — anything that rebuilds the
+    # agent-server image or modifies the SDK chat-options rewrite path.
+    # The patches script is the canonical place these regressions land
+    # (Patch 34 = Opus 4.7 adaptive thinking).
+    if [[ "$file" =~ docker/agent-server-custom/ ]] || [[ "$file" =~ docker/test_apply_sdk_patches\.py ]]; then
+        HAS_LLM_BEDROCK_CHANGES=true
     fi
 done
 
@@ -227,6 +245,17 @@ if $HAS_LIFECYCLE_CHANGES; then
     echo ""
     echo "## Conversation lifecycle changes detected:"
     for test in "${LIFECYCLE_TESTS[@]}"; do
+        tc="${test%%:*}"
+        name="${test#*:}"
+        echo "  - $tc: $name"
+        ADDITIONAL_TESTS+=("$test")
+    done
+fi
+
+if $HAS_LLM_BEDROCK_CHANGES; then
+    echo ""
+    echo "## LLM / Bedrock call-shape changes detected:"
+    for test in "${LLM_BEDROCK_TESTS[@]}"; do
         tc="${test%%:*}"
         name="${test#*:}"
         echo "  - $tc: $name"


### PR DESCRIPTION
## Summary

- Adds **SDK Patch 34** (`patch_34_opus_47_adaptive_thinking`) that rewrites `select_chat_options` output for Claude Opus 4.7 / Mythos Preview models so the Bedrock Converse API gets `thinking={"type":"adaptive"}` + top-level `output_config={"effort": ...}` instead of the rejected `thinking={"type":"enabled","budget_tokens":...}` shape.
- Sonnet 4.6, Sonnet 4.5, Haiku 4.5, Opus 4.5 and other extended-thinking models are untouched — only Opus 4.7 family is rewritten.
- 11 new unit tests in `TestPatch34Opus47AdaptiveThinking` (idempotency, missing-file, opus-4-7 / mythos / sonnet-4-6 / case-insensitive, beta-header strip, output_config gating, main() wiring).

## Why

The v1.7.0 upgrade (#81) E2E found that switching the agent's model to `bedrock/global.anthropic.claude-opus-4-7` fails with:

```
litellm.BadRequestError: BedrockException - "thinking.type.enabled" is not
supported for this model. Use "thinking.type.adaptive" and
"output_config.effort" to control thinking behavior.
```

Root cause chain:

1. The default `LLM` config has `reasoning_effort="high"`, `extended_thinking_budget=200000`.
2. SDK `model_features._supports_reasoning_effort` delegates to `litellm.get_supported_openai_params`, which reports `reasoning_effort` is supported for any `claude-opus-4*` model — so `select_chat_options` forwards `out["reasoning_effort"]="high"` to litellm.
3. litellm's bedrock converse translator (`_handle_reasoning_effort_parameter` in `litellm/llms/bedrock/chat/converse_transformation.py`) routes any non–GPT-OSS / non-Nova Anthropic model through `AnthropicConfig._map_reasoning_effort`, producing `thinking={"type":"enabled","budget_tokens":...}`.
4. Bedrock's Opus 4.7 API rejects that shape — it only accepts `"adaptive"`.

Upstream litellm hasn't shipped adaptive-thinking support yet. Tracked there in [BerriAI/litellm#25957](https://github.com/BerriAI/litellm/issues/25957), [#27168](https://github.com/BerriAI/litellm/issues/27168), [#26334](https://github.com/BerriAI/litellm/issues/26334).

## How

Patch 34 inserts a rewrite block before `return out` in `chat_options.py`:

```python
OPUS_47_ADAPTIVE_THINKING_MODELS = ["claude-opus-4-7", "claude-mythos-preview"]
if any(token in llm.model.lower() for token in OPUS_47_ADAPTIVE_THINKING_MODELS):
    effort = out.pop("reasoning_effort", None) or llm.reasoning_effort
    out.pop("thinking", None)
    out["thinking"] = {"type": "adaptive"}
    if effort and effort != "none":
        out["output_config"] = {"effort": effort}
    # strip legacy interleaved-thinking-2025-05-14 beta header (implicit under adaptive)
    # drop temperature/top_p (Anthropic thinking models ignore them)
```

Why this gets to Bedrock correctly: litellm passes `thinking` through directly (`if param == "thinking": optional_params["thinking"] = value`), and `output_config` is not in `AmazonConverseConfig.__annotations__`, so it lands in `additional_request_params` → `additionalModelRequestFields` — exactly where AWS docs say `output_config.effort` belongs for adaptive thinking.

This is a stop-gap. When upstream litellm gains adaptive-thinking support, this patch can be removed (and `model_features.EXTENDED_THINKING_MODELS` should be revisited so opus-4-7 gets first-class handling there).

## Design

- [x] Design discussed inline in the patch docstring (`patch_34_opus_47_adaptive_thinking`) — full bug chain, fix rationale, pointer to upstream issues
- [x] Approach approved (autonomous-dev workflow, follows the established pattern for patches 23–33)

## Test Plan

- [x] Build passes (`npm run build`)
- [x] Unit tests pass (`npm run test` — 131 TS + 102 Python = 233 tests, all green)
- [x] Code simplification review (code-simplifier agent) — minor inline-annotation cleanup
- [x] PR review agent — no critical / important findings
- [ ] CI checks pass
- [ ] Reviewer bot findings addressed (no new findings)
- [ ] E2E test on staging with Opus 4.7: switch e2e user model to `bedrock/global.anthropic.claude-opus-4-7`, send a prompt, expect a successful reply with no `thinking.type.enabled` error in app logs

## Checklist

- [x] New unit tests written for Patch 34 (11 tests covering all branches)
- [x] Test fixture stubs match the real chat_options.py / model_features.py contract
- [x] Snapshot updated for the new agent-server image hash
- [ ] E2E test cases updated if needed (existing test/E2E_TEST_CASES.md does not need changes — model switch is manual and covered by the test plan above)
- [ ] Documentation updated if needed (apply-sdk-patches.py top-of-file docstring already documents Patch 34)