### PR TITLE
docs(claude): require explicit user instruction before merging PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@
 Before ANY code changes — features, fixes, refactors, dependency bumps — you MUST:
 1. **Invoke skill**: Use `/autonomous-dev` or read `.claude/skills/autonomous-dev/SKILL.md`
 2. **Follow ALL steps** in order — NO shortcuts, NO skipping steps
-3. **Do NOT merge** - Report status and wait for user decision
+3. **Do NOT merge PRs** — Report status and wait for **explicit** user instruction to merge. A stop hook passing, CI passing, or review completing does NOT imply merge approval. Only merge when the user says "merge", "merge it", or equivalent.
 
 **Common violation**: Skipping skill invocation and jumping straight to coding. This causes missed steps (reviewer bot iteration, PR templates, E2E test selection). The skill is not optional guidance — it is the required process.
 


### PR DESCRIPTION
## Summary

Tightens Rule 1 step 3 in `CLAUDE.md` so future autonomous-dev runs cannot infer merge approval from CI / hook / review signals alone.

## Why

The Patch 34 PR (#83) sat for hours with everything green — CI passing, Amazon Q clean, code-simplifier and pr-review hooks both marked, E2E TC-035 verified end-to-end against staging — and the autonomous workflow correctly waited rather than self-merging until the user explicitly said "合并". This change documents that discipline so a future run with looser interpretation can't drift from it.

## How

```diff
-3. **Do NOT merge** - Report status and wait for user decision
+3. **Do NOT merge PRs** — Report status and wait for **explicit** user instruction to merge. A stop hook passing, CI passing, or review completing does NOT imply merge approval. Only merge when the user says "merge", "merge it", or equivalent.
```

Three ambiguous signals are now listed as explicitly NOT-implying-approval:
- Stop hook passing
- CI passing
- Review completing

And the approval keywords are spelled out: `"merge"`, `"merge it"`, "or equivalent".

## Test Plan

Docs-only — no behavior change in code.

- [x] Build passes (`npm run build`)
- [x] No tests need updating (the rule applies to assistant behavior, not code)
- [ ] CI checks pass

## Checklist

- [x] Single-line `CLAUDE.md` edit; no other files touched
- [x] Worktree-based change (per Rule 2)
- [x] Code-simplifier and pr-review hooks marked